### PR TITLE
Giving the option to overwrite hook during installation.

### DIFF
--- a/bin/pre-commit
+++ b/bin/pre-commit
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-require 'fileutils'
+require 'pre-commit/cli'
 
 PRE_COMMIT_HOOK_PATH = '.git/hooks/pre-commit'
 
@@ -14,14 +14,8 @@ if !File.exists?(".git")
   exit(1)
 end
 
-# TODO overwrite and backup?
-if File.exists?(PRE_COMMIT_HOOK_PATH)
-  puts "Not overwriting existing hook: #{PRE_COMMIT_HOOK_PATH}"
-  exit(1)
-end
-
-pre_commit_hook = File.expand_path('../../templates/pre-commit-hook', __FILE__)
-FileUtils.cp(pre_commit_hook, PRE_COMMIT_HOOK_PATH)
-FileUtils.chmod(0755, PRE_COMMIT_HOOK_PATH)
+cli = PreCommit::Cli.new
+cli.install
 
 puts "Installed hook: #{PRE_COMMIT_HOOK_PATH}"
+puts

--- a/lib/pre-commit/cli.rb
+++ b/lib/pre-commit/cli.rb
@@ -1,0 +1,42 @@
+require 'fileutils'
+require 'pre-commit/base'
+
+class PreCommit
+  class Cli
+
+    PRE_COMMIT_HOOK_PATH = '.git/hooks/pre-commit'
+
+    def answered_yes?(answer)
+      answer =~ /y\n/i || answer == "\n"
+    end
+
+    def install
+      if File.exists?(PRE_COMMIT_HOOK_PATH)
+        ask_to_overwrite
+      end
+
+      install_pre_commit_hook
+    end
+
+    def ask_to_overwrite
+      puts "pre-commit: WARNING There is already a pre-commit hook installed in this git repo."
+      print "Would you like to overwrite it? [Yn] "
+      answer = $stdin.gets
+
+      if answered_yes?(answer)
+        FileUtils.rm(PRE_COMMIT_HOOK_PATH)
+      else
+        puts "Not overwriting existing hook: #{PRE_COMMIT_HOOK_PATH}"
+        puts
+        exit(1)
+      end
+    end
+
+    def install_pre_commit_hook
+      hook = File.join(PreCommit.root, 'templates', 'pre-commit-hook')
+      FileUtils.cp(hook, PRE_COMMIT_HOOK_PATH)
+      FileUtils.chmod(0755, PRE_COMMIT_HOOK_PATH)
+    end
+
+  end
+end

--- a/test/unit/cli_test.rb
+++ b/test/unit/cli_test.rb
@@ -1,0 +1,20 @@
+require 'minitest/autorun'
+require 'pre-commit/cli'
+
+class CliTest < MiniTest::Unit::TestCase
+
+  def test_positive_answers
+    cli = PreCommit::Cli.new
+    assert cli.answered_yes?("y\n")
+    assert cli.answered_yes?("Y\n")
+    assert cli.answered_yes?("\n")
+  end
+
+  def test_negative_answers
+    cli = PreCommit::Cli.new
+    assert !cli.answered_yes?("n\n")
+    assert !cli.answered_yes?("N\n")
+    assert !cli.answered_yes?("j\n")
+  end
+
+end


### PR DESCRIPTION
Previously we were being extra safe and just aborting if we detected an existing git pre-commit hook. Now we ask the user if they would like use to replace their existing pre-commit hook.

As part of this commit a `PreCommit::Cli` class was created along with some basic test cases to test user responses.

/cc @shajith 

Q: In the event of an overwrite, should we back up the user's existing pre-commit hook or blow it away?
