### PR TITLE
Detect if pre-commit is actually installed in the ruby we are using.

### DIFF
--- a/templates/pre-commit-hook
+++ b/templates/pre-commit-hook
@@ -1,7 +1,12 @@
 #!/usr/bin/env ruby
 
 if system("which rvm > /dev/null")
-  cmd = "rvm default do ruby -rrubygems "
+  if system("rvm default do gem list | grep pre-commit > /dev/null")
+    cmd = "rvm default do ruby -rrubygems "
+  else
+    rvm_default = `rvm default do rvm current`
+    abort("Please install pre-commit in your RVM default Ruby: #{rvm_default}")
+  end
 else
   cmd = "ruby -rrubygems "
 end


### PR DESCRIPTION
When a user has RVM she might have managed to install pre-commit using an other ruby
then the default one. We must check that we have pre-commit in the ruby we are
running pre-commit from.

cc: @jish @shajith 
