### PR TITLE
Checking for the presence of the pre-commit gem.

### DIFF
--- a/templates/pre-commit-hook
+++ b/templates/pre-commit-hook
@@ -6,6 +6,12 @@ else
   cmd = "ruby -rrubygems "
 end
 
+if !system("#{cmd} -rpre-commit -e '' 2> /dev/null")
+  $stderr.puts "pre-commit: It looks like you've upgraded your ruby version."
+  $stderr.puts "Please re-install the pre-commit gem: `gem install pre-commit`"
+  exit(1)
+end
+
 cmd << %Q{-e "require 'pre-commit'; PreCommit.run"}
 
 exit(system(cmd) ? 0 : 1)


### PR DESCRIPTION
Sometimes people have a pre-commit hook installed that requires the pre-commit gem, but they do not have the pre-commit gem installed.

Typically this is caused by installing the pre-commit gem and hook, then upgrading to a newer version of Ruby.

The pre-commit hook still remains, but the new version of Ruby does not yet have the pre-commit gem installed. This check is a convenience to help guide users to re-install the gem for the new version of Ruby.

cc: @libo @shajith 
