### PR TITLE
Warning and passing when pre-commit fails to load.

### DIFF
--- a/templates/pre-commit-hook
+++ b/templates/pre-commit-hook
@@ -7,8 +7,7 @@ else
 end
 
 if !system("#{cmd} -rpre-commit -e '' 2> /dev/null")
-  $stderr.puts "pre-commit: WARNING: It looks like you've upgraded your Ruby version."
-  $stderr.puts "The pre-commit gem is not installed, skipping checks."
+  $stderr.puts "pre-commit: WARNING: Skipping checks because the pre-commit gem is not installed. (Did you change your Ruby version?)"
   exit(0)
 end
 


### PR DESCRIPTION
We want to be safer about detecting a hook, but a missing pre-commit gem, but we don't want to error out.

We want a warning to be displayed, and the commit to proceed.

cc: @libo @shajith 

cf: #24
