### PR TITLE
Update templates/pre-commit-hook

### DIFF
--- a/templates/pre-commit-hook
+++ b/templates/pre-commit-hook
@@ -9,7 +9,7 @@ else
 end
 cmd << " -r pre-commit"
 
-if !system("#{cmd} -e '' 2>&1")
+if !system("#{cmd} -e ';' 2>&1")
   $stderr.puts "pre-commit: WARNING: Skipping checks because the pre-commit gem is not installed. (Did you change your Ruby version?)"
   exit(0)
 end


### PR DESCRIPTION
fix `ruby: no code specified for -e (RuntimeError)` error
