### PR TITLE
Add Pry Check

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ These are the available checks:
 * white_space
 * console_log
 * debugger
+* pry
 * tabs
 * jshint
 * js\_lint\_all (Runs JSLint on all staged JS files)
@@ -46,4 +47,4 @@ To enable `white_space`, `console_log` and `debugger` checks:
 
 Note: If no checks are configured, a default set of checks is run:
 
-    white_space, console_log, debugger, tabs, jshint, migrations, merge_conflict, local
+    white_space, console_log, debugger, pry, tabs, jshint, migrations, merge_conflict, local

--- a/lib/pre-commit/checks.rb
+++ b/lib/pre-commit/checks.rb
@@ -10,6 +10,7 @@ require 'pre-commit/checks/jshint_check'
 require 'pre-commit/checks/migration_check'
 require 'pre-commit/checks/ci_check'
 require 'pre-commit/checks/php_check'
+require 'pre-commit/checks/pry_check'
 require 'pre-commit/checks/ruby_symbol_hashrockets'
 
 module PreCommit
@@ -35,6 +36,7 @@ module PreCommit
     :js_lint_new             => JslintCheck.new(:new),
     :jshint                  => JshintCheck.new,
     :debugger                => DebuggerCheck,
+    :pry                     => PryCheck,
     :local                   => LocalCheck,
     :tabs                    => Tabs,
     :closure_syntax_check    => ClosureSyntaxCheck,
@@ -60,7 +62,7 @@ module PreCommit
     checks_to_run = `git config pre-commit.checks`.chomp.split(/,\s*/).map(&:to_sym)
 
     if checks_to_run.empty?
-      Checks.values_at(:white_space, :console_log, :debugger, :tabs, :jshint,
+      Checks.values_at(:white_space, :console_log, :debugger, :pry, :tabs, :jshint,
         :migrations, :merge_conflict, :local)
     else
       Checks.values_at(*checks_to_run)

--- a/lib/pre-commit/checks/pry_check.rb
+++ b/lib/pre-commit/checks/pry_check.rb
@@ -1,0 +1,47 @@
+module PreCommit
+  class PryCheck
+
+    attr_accessor :staged_files, :error_message, :grep_command
+
+    def self.call(quiet=false)
+      dirs = ['app/', 'lib/', 'script/', 'vendor/', 'test/'].reject {|d| !File.exists?(d)}
+      check = new
+      check.staged_files = Utils.staged_files(*dirs)
+
+      result = check.run
+      if !quiet && !result
+        $stderr.puts check.error_message
+        $stderr.puts
+        check.print_dash_n_reminder
+      end
+      result
+    end
+
+    def run
+      return true if staged_files.empty?
+
+      if detected_bad_code?
+        @error_message = "pre-commit: binding.pry statement(s) found:\n"
+        @error_message += instances_of_pry_violations
+        false
+      else
+        true
+      end
+    end
+
+    def detected_bad_code?
+      !system("git diff --cached -S binding.pry --quiet --exit-code")
+    end
+
+    def instances_of_pry_violations
+      cmd = grep_command || "git grep"
+      `#{cmd} -nH "binding\.pry" #{staged_files}`
+    end
+
+    def print_dash_n_reminder
+      $stderr.puts 'You can bypass this check using `git commit -n`'
+      $stderr.puts
+    end
+
+  end
+end

--- a/test/files/pry_file.rb
+++ b/test/files/pry_file.rb
@@ -1,0 +1,5 @@
+class PryFile
+  def blam
+    binding.pry
+  end
+end

--- a/test/unit/pry_check_test.rb
+++ b/test/unit/pry_check_test.rb
@@ -1,0 +1,31 @@
+require 'minitest_helper'
+require 'pre-commit/checks/pry_check'
+
+class PryCheckTest < MiniTest::Unit::TestCase
+
+  def test_should_detect_a_binding_pry_statement
+    check = PreCommit::PryCheck.new
+    check.grep_command = "grep"
+    check.staged_files = test_filename('pry_file.rb')
+    assert !check.instances_of_pry_violations.empty?
+  end
+
+  def test_should_pass_a_file_with_no_binding_pry_statement
+    check = PreCommit::PryCheck.new
+    check.grep_command = "grep"
+    check.staged_files = test_filename('valid_file.rb')
+    assert check.instances_of_pry_violations.empty?
+  end
+
+  def test_error_message_should_contain_an_error_message_when_a_binding_pry_statement_is_found
+    check = PreCommit::PryCheck.new
+    def check.detected_bad_code?; true; end
+    check.grep_command = "grep"
+    check.staged_files = test_filename('pry_file.rb')
+    check.run
+
+    assert_match(/pre-commit: binding.pry statement\(s\) found:/, check.error_message)
+    assert_match(/pry_file.rb/, check.error_message)
+  end
+
+end


### PR DESCRIPTION
Adds a check for `binding.pry` occurrences in ruby files. Based on the debugger check.

https://github.com/pry/pry
