### PR TITLE
support warnings in addition to errors on commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ Note: If no checks are configured, a default set of checks is run:
 
     white_space, console_log, debugger, pry, tabs, jshint, migrations, merge_conflict, local
 
+You may also enable checks that will produce warnings if detected but NOT stop the commit:
+
+    # From your git repo
+    $ git config "pre-commit.warnings" "jshint, ruby_symbol_hashrockets"
+
+
 For the rubocop check, you can tell it what config file to use by setting a path relative to the repo:
 
     # From your git repo

--- a/lib/pre-commit/checks.rb
+++ b/lib/pre-commit/checks.rb
@@ -57,6 +57,7 @@ module PreCommit
   # we want, and nobody is forced to update their pre-commit binary.
   def self.checks_to_run
     checks_to_run = `git config pre-commit.checks`.chomp.split(/,\s*/).map(&:to_sym)
+    warnings_to_run = `git config pre-commit.warnings`.chomp.split(/,\s*/).map(&:to_sym)
 
     if checks_to_run.empty?
       CHECKS.values_at(:white_space, :console_log, :debugger, :pry, :tabs, :jshint,
@@ -73,8 +74,18 @@ module PreCommit
     end.compact
   end
 
+  def self.warnings_to_run
+    warnings_to_run = `git config pre-commit.warnings`.chomp.split(/,\s*/).map(&:to_sym)
+    CHECKS.values_at(*warnings_to_run).compact
+  end
+
   def self.run
     staged_files = Utils.staged_files
+    warnings = warnings_to_run.map { |cmd| cmd.call(staged_files.dup) }.compact
+    if warnings.any?
+       $stderr.puts "pre-commit: Some warnings were raised. These will not stop commit:"
+       $stderr.puts warnings.join("\n")
+    end
     errors = checks_to_run.map { |cmd| cmd.call(staged_files.dup) }.compact
     if errors.any?
       $stderr.puts "pre-commit: Stopping commit because of errors."


### PR DESCRIPTION
Love the gem @jish!  Planning another pull request to add support for my gem, outlaw, as this makes easier some of the work I wanted to do on it for a while, but this functionality is something I definitely want to support, and rather than adding it to my gem, I thought it made sense here.  Let me know if you have any questions or prefer it to be done any differentyly, but tested it locally and it worked well for me.  Thanks!
