### PR TITLE
Just use Ruby

### DIFF
--- a/lib/pre-commit/support/templates/pre-commit-hook
+++ b/lib/pre-commit/support/templates/pre-commit-hook
@@ -1,18 +1,11 @@
 #!/usr/bin/env ruby
 
-OPTIONS = "-r rubygems"
-
-cmd = if system("which rvm > /dev/null")
-  "rvm default do ruby"
-elsif system("which rbenv > /dev/null")
-  "rbenv exec ruby"
-else
-  "ruby"
-end
-
-if !system(%Q{#{cmd} #{OPTIONS} -e "require 'pre-commit';" 2>&1})
+begin
+  require 'pre-commit'
+  PreCommit.run
+rescue LoadError
   $stderr.puts "pre-commit: WARNING: Skipping checks because the pre-commit gem is not installed. (Did you change your Ruby version?)"
   exit(0)
+rescue SystemExit => e
+  exit(e.status)
 end
-
-exec(%Q{#{cmd} #{OPTIONS} -e "require 'pre-commit'; PreCommit.run"})


### PR DESCRIPTION
There should be no need to start two new ruby processes to find out if the `pre-commit` gem is available or not.

Also, the script is already ruby. Just run pre-commit in the same process.
