### PR TITLE
Attempt to run checks in process first.

### DIFF
--- a/lib/pre-commit/support/templates/pre-commit-hook
+++ b/lib/pre-commit/support/templates/pre-commit-hook
@@ -1,18 +1,29 @@
 #!/usr/bin/env ruby
 
-OPTIONS = "-r rubygems"
+begin
 
-cmd = if system("which rvm > /dev/null")
-  "rvm default do ruby"
-elsif system("which rbenv > /dev/null")
-  "rbenv exec ruby"
-else
-  "ruby"
+  # First try to just run the check here
+  require 'pre-commit'
+  PreCommit.run
+
+rescue LoadError
+
+  # If there are loading problems, try to help the user
+  OPTIONS = "-r rubygems"
+
+  cmd = if system("which rvm > /dev/null")
+    "rvm default do ruby"
+  elsif system("which rbenv > /dev/null")
+    "rbenv exec ruby"
+  else
+    "ruby"
+  end
+
+  if !system(%Q{#{cmd} #{OPTIONS} -e "require 'pre-commit';" 2>&1})
+    $stderr.puts "pre-commit: WARNING: Skipping checks because the pre-commit gem is not installed. (Did you change your Ruby version?)"
+    exit(0)
+  end
+
+  exec(%Q{#{cmd} #{OPTIONS} -e "require 'pre-commit'; PreCommit.run"})
+
 end
-
-if !system(%Q{#{cmd} #{OPTIONS} -e "require 'pre-commit';" 2>&1})
-  $stderr.puts "pre-commit: WARNING: Skipping checks because the pre-commit gem is not installed. (Did you change your Ruby version?)"
-  exit(0)
-end
-
-exec(%Q{#{cmd} #{OPTIONS} -e "require 'pre-commit'; PreCommit.run"})


### PR DESCRIPTION
If `requiring` `pre-commit` in process fails, then fall back. Attempt to introspect the users environment and find the `pre-commit` gem for them.

---

We've been trying to strike a balance between performance and portability for the `pre-commit` hook template for a while. This seems like a nice middle ground, thanks everyone for your input! (:
