### PR TITLE
Fix whitespace checker for case sensitive OSs (aka linux)

### DIFF
--- a/lib/pre-commit/checks/whitespace_check.rb
+++ b/lib/pre-commit/checks/whitespace_check.rb
@@ -1,11 +1,11 @@
 module PreCommit
   class WhiteSpaceCheck
     def self.call(_)
-      errors = `git diff-index --check --cached head -- 2>&1`
+      errors = `git diff-index --check --cached HEAD -- 2>&1`
       return if $?.success?
 
       # Initial commit: diff against the empty tree object
-      if errors =~ /fatal: bad revision 'head'/
+      if errors =~ /fatal: bad revision 'HEAD'/
         errors = `git diff-index --check --cached 4b825dc642cb6eb9a060e54bf8d69288fbee4904 -- 2>&1`
         return if $?.success?
       end


### PR DESCRIPTION
The whitespace checker was always doing the check on the first commit
because on case sensitive OSs 'head' is always a bad revision.
