### PR TITLE
hardwired dependencies for execjs

### DIFF
--- a/lib/plugins/pre_commit/checks/js.rb
+++ b/lib/plugins/pre_commit/checks/js.rb
@@ -1,10 +1,13 @@
 require 'pre-commit/utils'
-require 'execjs'
 
 module PreCommit
   module Checks
     class Js
       def self.call(staged_files)
+        require 'execjs'
+      rescue RuntimeError, LoadError => e
+        $stderr.puts "Could not load execjs: #{e}"
+      else
         staged_files = staged_files.select { |f| File.extname(f) == ".js" }
         return if staged_files.empty?
 


### PR DESCRIPTION
The hard-wired requires cause commit hook to blow up on 'execjs not found' even if the JS tests are explicitly turned off.

```
from /home/jakub/.rvm/gems/ree-1.8.7-2011.03/gems/execjs-1.2.6/lib/execjs.rb:5
from /home/jakub/.rvm/rubies/ree-1.8.7-2011.03/lib/ruby/site_ruby/1.8/rubygems/custom_require.rb:36:in `gem_original_require'
from /home/jakub/.rvm/rubies/ree-1.8.7-2011.03/lib/ruby/site_ruby/1.8/rubygems/custom_require.rb:36:in `require'
from /home/jakub/.rvm/gems/ree-1.8.7-2011.03/gems/pre-commit-0.1.16/lib/pre-commit/checks/js_check.rb:3
from /home/jakub/.rvm/rubies/ree-1.8.7-2011.03/lib/ruby/site_ruby/1.8/rubygems/custom_require.rb:36:in `gem_original_require'
from /home/jakub/.rvm/rubies/ree-1.8.7-2011.03/lib/ruby/site_ruby/1.8/rubygems/custom_require.rb:36:in `require'
from /home/jakub/.rvm/gems/ree-1.8.7-2011.03/gems/pre-commit-0.1.16/lib/pre-commit/checks/jslint_check.rb:1
from /home/jakub/.rvm/rubies/ree-1.8.7-2011.03/lib/ruby/site_ruby/1.8/rubygems/custom_require.rb:36:in `gem_original_require'
from /home/jakub/.rvm/rubies/ree-1.8.7-2011.03/lib/ruby/site_ruby/1.8/rubygems/custom_require.rb:36:in `require'
from /home/jakub/.rvm/gems/ree-1.8.7-2011.03/gems/pre-commit-0.1.16/lib/pre-commit/checks.rb:7
from /home/jakub/.rvm/rubies/ree-1.8.7-2011.03/lib/ruby/site_ruby/1.8/rubygems/custom_require.rb:36:in `gem_original_require'
from /home/jakub/.rvm/rubies/ree-1.8.7-2011.03/lib/ruby/site_ruby/1.8/rubygems/custom_require.rb:36:in `require'
from /home/jakub/.rvm/gems/ree-1.8.7-2011.03/gems/pre-commit-0.1.16/lib/pre-commit.rb:1
from /home/jakub/.rvm/rubies/ree-1.8.7-2011.03/lib/ruby/site_ruby/1.8/rubygems/custom_require.rb:58:in `gem_original_require'
from /home/jakub/.rvm/rubies/ree-1.8.7-2011.03/lib/ruby/site_ruby/1.8/rubygems/custom_require.rb:58:in `require'
from .git/hooks/pre-commit:3
```
