### PR TITLE
force utf-8 encoding

### DIFF
--- a/lib/plugins/pre_commit/checks/nb_space.rb
+++ b/lib/plugins/pre_commit/checks/nb_space.rb
@@ -6,7 +6,7 @@ module PreCommit
         nb_space = " "
         raise "you messed that up" unless nb_space.bytes.to_a == [194, 160]
 
-        staged_files.reject! { |f| f =~ /^vendor\// || !File.read(f).include?(nb_space) }
+        staged_files.reject! { |f| f =~ /^vendor\// || !File.read(f, encoding: 'utf-8').include?(nb_space) }
 
         bad = staged_files.map do |file|
           content = File.read(file).lines.to_a


### PR DESCRIPTION
I just wanted to signal the problem I had. This is a slight hack to force everything to be encoded in utf-8.

I had tried magic encoding in some files (#encoding: utf-8) and it didn't helped. So I ended up editing this file to cope with this problem.
