### PR TITLE
timeout for old issues

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,26 @@
+# Contributing
+
+## Reporting issues
+
+Please provide as much details as possible.
+
+### Closing old issues
+
+Tickets that require user feedback will be marked with `need-info`
+label. In case there will be no feedback on such ticket in two
+months we will close that ticket. the ticket will be reopened as
+soon as user can provide requested information.
+
+## Adding extra check plugins
+
+You can add extra checks by creating gem with a new check in
+`lib/plugins/pre_commit/checks/`, check this project directory for
+examples:
+[lib/plugins/pre_commit/checks](lib/plugins/pre_commit/checks).
+
+## Adding extra configuration provider plugins
+
+You can add extra providers by creating gem with a new provider in
+`lib/plugins/pre_commit/configuration/providers/`, check this
+project directory for examples:
+[lib/plugins/pre_commit/configuration/providers](lib/plugins/pre_commit/configuration/providers).

--- a/README.md
+++ b/README.md
@@ -47,11 +47,6 @@ These are the available checks:
 
 Use `pre-commit list` to see the list of default and enabled checks and warnings.
 
-### Adding extra check plugins
-
-You can add extra checks by creating gem with a new check in `lib/plugins/pre_commit/checks/`,
-check this project directory for examples: [lib/plugins/pre_commit/checks](lib/plugins/pre_commit/checks).
-
 ## Enabling / Disabling Checks / Warnings
 
 Usage:
@@ -78,7 +73,4 @@ git commit -m "pre-commit: move jshint from checks to warnings"
 - `git` - reads configuration from `git config pre-commit.*`, allow local update
 - `yaml` - reads configuration from `/etc/pre-commit.yml`, `$HOME/.pre-commit.yml` and `config/pre-commit.yml`, allows `config/pre-commit.yml` updates
 
-### Adding extra configuration provider plugins
-
-You can add extra providers by creating gem with a new provider in `lib/plugins/pre_commit/configuration/providers/`,
-check this project directory for examples: [lib/plugins/pre_commit/configuration/providers](lib/plugins/pre_commit/configuration/providers).
+## [Contributing](CONTRIBUTING.md)


### PR DESCRIPTION
@jish for [RVM](https://github.com/wayneeseguin/rvm) I have a rule of closing issues with no response in two weeks, having a timeout prevents old issues laying around even when there is no feedback form the creator of the issue, you can pick any other timeout then two weeks, but having one would help to keep order in the tickets.
