### PR TITLE
adds support for Go source files checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ These are the available checks:
 * rubocop (Check ruby code style using the rubocop gem. Rubocop must be installed)
 * before_all (Check your RSpec tests for the use of `before(:all)`)
 * coffeelint (Check your coffeescript files using the [coffeelint gem.](https://github.com/clutchski/coffeelint))
+* go (Runs go fmt on a go source file and fail if formatting is incorrect, then runs go build and fails if can't compile)
 
 ## Default checks
 

--- a/lib/plugins/pre_commit/checks/go.rb
+++ b/lib/plugins/pre_commit/checks/go.rb
@@ -1,0 +1,29 @@
+require 'pre-commit/checks/plugin'
+
+module PreCommit
+  module Checks
+    class Go < Plugin
+
+      def call(staged_files)
+        staged_files = staged_files.grep(/\.go$/)
+        return if staged_files.empty?
+
+        errors = staged_files.map { |file| run_check(file) }.compact
+        return if errors.empty?
+
+        errors.join("\n")
+      end
+
+      def run_check(file)
+        cmd = "gofmt -l #{file} 2>&1"
+        result = %x[ #{cmd} ]
+        cmd = "go build -o /dev/null #{file} 2>&1"
+        result << %x[ #{cmd} ]
+      end
+
+      def self.description
+        "Detects bad Go formatting and compiler errors"
+      end
+    end
+  end
+end

--- a/test/files/bad_fmt.go
+++ b/test/files/bad_fmt.go
@@ -1,0 +1,5 @@
+package main
+
+func main() {
+return
+}

--- a/test/files/dont_compile.go
+++ b/test/files/dont_compile.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	return
+}

--- a/test/files/good.go
+++ b/test/files/good.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Printf("I'm good\n")
+}

--- a/test/unit/plugins/pre_commit/checks/go_test.rb
+++ b/test/unit/plugins/pre_commit/checks/go_test.rb
@@ -1,0 +1,22 @@
+require 'minitest_helper'
+require 'plugins/pre_commit/checks/go'
+
+describe PreCommit::Checks::Go do
+  let(:check) {PreCommit::Checks::Go.new(nil, nil, [])}
+
+  it "succeds if nothing changed" do
+    check.call([]).must_equal nil
+  end
+
+  it "succeeds for good code" do
+    check.call([fixture_file('good.go')]).must_equal ""
+  end
+
+  it "fails for bad formatted code" do
+    check.call([fixture_file("bad_fmt.go")]).must_match(/bad_fmt.go/)
+  end
+
+  it "fails for compiler errors" do
+    check.call([fixture_file("dont_compile.go")]).must_match(/imported and not used/)
+  end
+end


### PR DESCRIPTION
This PR addes support for Go source files.

First it'll run gofmt then go build, so it fails if the formatting is incorrect and/or if the source file can't compile.

\cc @jish
