### PR TITLE
Provide standard way to specify config file.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gemspec
 group :development do
   # checks that do not have to be enabled
   gem "execjs"
-  gem "rubocop",          :platforms => [:ruby_19, :ruby_20]
+  gem "rubocop"
 
   # statistics only on MRI 2.0 - avoid problems on older rubies
   gem "redcarpet", :platforms => [:mri_20]

--- a/README.md
+++ b/README.md
@@ -86,10 +86,11 @@ Example `config/pre_commit.yml`:
 
 ## Configuration providers
 
-`pre-commit` comes with 3 configuration providers:
+`pre-commit` comes with 4 configuration providers:
 
 - `default` - basic settings, read only
 - `git` - reads configuration from `git config pre-commit.*`, allow local update
 - `yaml` - reads configuration from `/etc/pre-commit.yml`, `$HOME/.pre-commit.yml` and `config/pre-commit.yml`, allows `config/pre-commit.yml` updates
+- `env` - reads configuration from environment variables
 
 ## [Contributing](CONTRIBUTING.md)

--- a/lib/plugins/pre_commit/checks/coffeelint.rb
+++ b/lib/plugins/pre_commit/checks/coffeelint.rb
@@ -9,10 +9,18 @@ module PreCommit
         staged_files = staged_files.grep(/\.coffee$/)
         return if staged_files.empty?
 
-        args = staged_files.join(' ')
+        args = (config_file_flag + staged_files).join(' ')
 
         stdout, stderr, result = Open3.capture3("coffeelint #{args}")
         stdout + stderr unless result.success?
+      end
+
+      def config_file_flag
+        config_file ? ['-f', config_file] : []
+      end
+
+      def alternate_config_file
+        'coffeelint.json'
       end
 
       def self.description

--- a/lib/plugins/pre_commit/checks/jshint.rb
+++ b/lib/plugins/pre_commit/checks/jshint.rb
@@ -4,8 +4,8 @@ module PreCommit
   module Checks
     class Jshint < Js
 
-      def config
-        if config_file = [ENV['JSHINT_CONFIG'], ".jshintrc"].compact.detect { |f| File.exist?(f) }
+      def js_config
+        if config_file
           ExecJS.exec("return (#{File.read(config_file)});")
         else
           {}
@@ -14,11 +14,15 @@ module PreCommit
 
       def run_check(file)
         context = ExecJS.compile(File.read(linter_src))
-        context.call("JSHINT", File.read(file), config, config["globals"])
+        context.call("JSHINT", File.read(file), js_config, js_config["globals"])
       end
 
       def linter_src
         File.expand_path("../../../../pre-commit/support/jshint/jshint.js", __FILE__)
+      end
+
+      def alternate_config_file
+        ".jshintrc"
       end
 
       def self.description

--- a/lib/plugins/pre_commit/checks/rubocop.rb
+++ b/lib/plugins/pre_commit/checks/rubocop.rb
@@ -20,21 +20,8 @@ module PreCommit
       else
         staged_files = staged_files.grep(/\.rb$/)
         return if staged_files.empty?
-        config_file = config.get('rubocop.config')
 
-        args = staged_files
-        if !config_file.empty?
-          if !File.exist? config_file
-            $stderr.puts "Warning: rubocop config file '" + config_file + "' does not exist"
-            $stderr.puts "Set the path to the config file using:"
-            $stderr.puts "\tgit config pre-commit.rubocop.config 'path/relative/to/git/dir/rubocop.yml'"
-            $stderr.puts "Or in 'config/pre-commit.yml':"
-            $stderr.puts "\trubocop.config: path/relative/to/git/dir/rubocop.yml"
-            $stderr.puts "rubocop will use its default configuration or look for a .rubocop.yml file\n\n"
-          else
-            args = ['-c', config_file] + args
-          end
-        end
+        args = config_file_flag + staged_files
 
         success, captured = capture { ::Rubocop::CLI.new.run(args) == 0 }
         captured unless success
@@ -48,6 +35,14 @@ module PreCommit
       ensure
         $stdout = stdout
         $stderr = stderr
+      end
+
+      def config_file_flag
+        config_file ? ['-c', config_file] : []
+      end
+
+      def alternate_config_file
+        '.rubocop.yml'
       end
 
       def self.description

--- a/lib/plugins/pre_commit/configuration/providers/env.rb
+++ b/lib/plugins/pre_commit/configuration/providers/env.rb
@@ -1,0 +1,26 @@
+module PreCommit
+  class Configuration
+    class Providers
+
+      class Env
+        def self.priority
+          30
+        end
+
+        def [](name)
+          ENV[key(name)]
+        end
+
+        def update(name, value)
+          ENV[key(name)] = value
+        end
+
+      private
+
+        def key(name)
+          name.to_s.upcase.split('.').join('_')
+        end
+      end
+    end
+  end
+end

--- a/lib/pre-commit/checks/plugin.rb
+++ b/lib/pre-commit/checks/plugin.rb
@@ -1,12 +1,32 @@
+require 'plugins/pluginator/extensions/conversions'
+require 'pre-commit/checks/plugin/config_file'
+
 module PreCommit
   module Checks
     class Plugin
+      include Pluginator::Extensions::Conversions
+
       attr_accessor :pluginator, :config
 
       def initialize(pluginator, config, list)
         @pluginator = pluginator
         @config     = config
         @list       = list
+      end
+
+      def name
+        class2string(class2name(self.class))
+      end
+
+    private
+
+      def config_file
+        @config_file ||= ConfigFile.new(name, config, alternate_config_file)
+        @config_file.location
+      end
+
+      def alternate_config_file
+        ''
       end
     end
   end

--- a/lib/pre-commit/checks/plugin/config_file.rb
+++ b/lib/pre-commit/checks/plugin/config_file.rb
@@ -1,0 +1,68 @@
+module PreCommit
+  module Checks
+    class Plugin
+      class ConfigFile
+        def initialize(name, config, alternate_location)
+          @name = name
+          @config = config
+          @alternate_location = alternate_location
+        end
+
+        def location
+          return @location if defined?(@location)
+
+          @location = location_from_config || location_from_alternate
+        end
+
+      private
+        attr_reader :name, :config, :alternate_location
+
+        def location_from_config
+          location_from(config_location, true)
+        end
+
+        def location_from_alternate
+          location_from(alternate_location)
+        end
+
+        def location_from(location, show_usage = false)
+          if location && !location.empty?
+            if File.exist?(location)
+              location
+            else
+              usage if show_usage
+              nil
+            end
+          end
+        end
+
+        def config_location
+          @config_location ||= config.get(property_name)
+        end
+
+        def property_name
+          "#{name}.config"
+        end
+
+        def environment_variable_name
+          "#{name.upcase}_CONFIG"
+        end
+
+        def yaml_property_name
+          property_name.gsub(/_/, '.')
+        end
+
+        def usage
+          $stderr.puts "Warning: #{name} config file '#{config_location}' does not exist"
+          $stderr.puts "Set the path to the config file using:"
+          $stderr.puts "\tgit config pre-commit.#{property_name} 'path/relative/to/git/dir/#{name}.config'"
+          $stderr.puts "Or in 'config/pre-commit.yml':"
+          $stderr.puts "\t#{yaml_property_name}: path/relative/to/git/dir/#{name}.config"
+          $stderr.puts "Or set the environment variable:"
+          $stderr.puts "\texport #{environment_variable_name}='path/relative/to/git/dir/#{name}.config'"
+          $stderr.puts "#{name} will look for a configuration file in the project root or use its default behavior.\n\n"
+        end
+      end
+    end
+  end
+end

--- a/test/files/valid_file.rb
+++ b/test/files/valid_file.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 
+# class docs for rubocop
 class ValidFile
-  # class docs for rubocop
   def no_problems_here!
   end
 end

--- a/test/unit/plugins/pre_commit/checks/jshint_test.rb
+++ b/test/unit/plugins/pre_commit/checks/jshint_test.rb
@@ -3,7 +3,13 @@ require 'plugins/pre_commit/checks/jshint'
 require 'execjs'
 
 describe PreCommit::Checks::Jshint do
-  let(:check){ PreCommit::Checks::Jshint.new(nil, nil, []) }
+  let(:config) do
+    mock = MiniTest::Mock.new
+    mock.expect(:get, '', ['jshint.config'])
+    mock
+  end
+
+  let(:check){ PreCommit::Checks::Jshint.new(nil, config, []) }
 
   it "succeeds if nothing changed" do
     check.call([]).must_equal nil

--- a/test/unit/plugins/pre_commit/checks/rubocop_test.rb
+++ b/test/unit/plugins/pre_commit/checks/rubocop_test.rb
@@ -1,20 +1,25 @@
 require 'minitest_helper'
 require 'plugins/pre_commit/checks/rubocop'
 
-  describe PreCommit::Checks::Rubocop do
-    let(:check){ PreCommit::Checks::Rubocop.new(nil, nil, []) }
+describe PreCommit::Checks::Rubocop do
+  let(:config) do
+    mock = MiniTest::Mock.new
+    mock.expect(:get, '', ['rubocop.config'])
+    mock
+  end
 
-    it "succeeds if nothing changed" do
-      check.call([]).must_equal nil
-    end
+  let(:check){ PreCommit::Checks::Rubocop.new(nil, config, []) }
 
-    it "succeeds if only good changes" do
-      check.call([fixture_file('valid_file.rb')]).must_equal nil
-    end
+  it "succeeds if nothing changed" do
+    check.call([]).must_equal nil
+  end
 
-    it "fails if file contains errors" do
-      # rubinius finds only 1 offense, all others find 2
-      check.call([fixture_file('merge_conflict.rb')]).must_match /1 file inspected, \e\[31m[12] offences? detected\e\[0m/
-    end
-  end if PreCommit.const_defined?('RubocopCheck')
+  it "succeeds if only good changes" do
+    check.call([fixture_file('valid_file.rb')]).must_equal nil
+  end
 
+  it "fails if file contains errors" do
+    # rubinius finds only 1 offense, all others find 2
+    check.call([fixture_file('merge_conflict.rb')]).must_match /1 file inspected, (\e\[31m)?[12] offences? detected/
+  end
+end

--- a/test/unit/plugins/pre_commit/configuration/providers/env_test.rb
+++ b/test/unit/plugins/pre_commit/configuration/providers/env_test.rb
@@ -1,0 +1,37 @@
+require 'minitest_helper'
+require 'plugins/pre_commit/configuration/providers/env'
+
+describe PreCommit::Configuration::Providers::Env do
+  subject do
+    PreCommit::Configuration::Providers::Env
+  end
+
+  it "has priority" do
+    subject.priority.must_equal(30)
+  end
+
+  describe :environment do
+    subject do
+      PreCommit::Configuration::Providers::Env.new
+    end
+
+    before do
+      ENV['GETTABLE_CONFIGURATION'] = 'test'
+      ENV['SETTABLE_CONFIGURATION'] = nil
+    end
+
+    after do
+      ENV['GETTABLE_CONFIGURATION'] = nil
+      ENV['SETTABLE_CONFIGURATION'] = nil
+    end
+
+    it 'reads from the environment' do
+      subject['gettable.configuration'].must_equal('test')
+    end
+
+    it 'writes to the environment' do
+      subject.update('settable.configuration', 'test')
+      ENV['SETTABLE_CONFIGURATION'].must_equal('test')
+    end
+  end
+end

--- a/test/unit/pre-commit/checks/plugin/config_file_test.rb
+++ b/test/unit/pre-commit/checks/plugin/config_file_test.rb
@@ -1,0 +1,74 @@
+require 'minitest_helper'
+require 'tempfile'
+require 'stringio'
+require 'pre-commit/checks/plugin/config_file'
+
+describe PreCommit::Checks::Plugin::ConfigFile do
+  let(:temp_config_file){ Tempfile.new('config.file') }
+  let(:config){ MiniTest::Mock.new }
+  let(:alternate_location){temp_config_file.path}
+  subject do
+    PreCommit::Checks::Plugin::ConfigFile.new('my_plugin', config, alternate_location)
+  end
+
+  describe 'when configuration is specified by a provider' do
+    describe 'when the file exists' do
+      it 'returns the provider specified configuration when it exists' do
+        config.expect(:get, temp_config_file.path, ['my_plugin.config'])
+
+        subject.location.must_equal(temp_config_file.path)
+        config.verify
+      end
+    end
+
+    describe 'when file does not exist' do
+      it 'displays a usage message when the file does not exist' do
+        config.expect(:get, 'missing.config', ['my_plugin.config'])
+
+        stderr, $stderr = $stderr, StringIO.new
+        subject.location
+        stderr, $stderr = $stderr, stderr
+
+        stderr.string.must_equal <<-USAGE
+Warning: my_plugin config file 'missing.config' does not exist
+Set the path to the config file using:
+\tgit config pre-commit.my_plugin.config 'path/relative/to/git/dir/my_plugin.config'
+Or in 'config/pre-commit.yml':
+\tmy.plugin.config: path/relative/to/git/dir/my_plugin.config
+Or set the environment variable:
+\texport MY_PLUGIN_CONFIG='path/relative/to/git/dir/my_plugin.config'
+my_plugin will look for a configuration file in the project root or use its default behavior.
+
+USAGE
+        config.verify
+      end
+    end
+  end
+
+  describe 'when configuration is not specified by a provider and alternate location is specified' do
+    before{ config.expect(:get, nil, ['my_plugin.config']) }
+
+    describe 'when the file exists' do
+      it 'returns the alternate location' do
+        subject.location.must_equal(temp_config_file.path)
+      end
+    end
+
+    describe 'when the file does not exist' do
+      let(:alternate_location){ 'missing.config' }
+
+      it 'returns nil' do
+        subject.location.must_equal(nil)
+      end
+    end
+  end
+
+  describe 'when no configuration is specified' do
+    before{ config.expect(:get, nil, ['my_plugin.config']) }
+    let(:alternate_location){ nil }
+
+    it 'returns nil' do
+      subject.location.must_equal(nil)
+    end
+  end
+end

--- a/test/unit/pre-commit/cli_test.rb
+++ b/test/unit/pre-commit/cli_test.rb
@@ -45,7 +45,7 @@ describe PreCommit::Cli do
     cli.execute.must_equal(true)
     $stderr.string.must_equal('')
     $stdout.string.gsub(/\s+\n/,"\n").must_equal(<<-EXPECTED)
-Available providers: default(0) git(10) git_old(11) yaml(20)
+Available providers: default(0) git(10) git_old(11) yaml(20) env(30)
 Available checks   : before_all ci closure coffeelint common console_log csslint debugger gemfile_path go jshint jslint local merge_conflict migration nb_space php pry rails rspec_focus rubocop ruby ruby_symbol_hashrockets tabs whitespace
 Default   checks   : common rails
 Enabled   checks   : common rails
@@ -76,7 +76,7 @@ EXPECTED
     cli.execute.must_equal(true)
     $stderr.string.must_equal('')
     $stdout.string.gsub(/\s+\n/,"\n").must_equal(<<-EXPECTED)
-Available providers: default(0) git(10) git_old(11) yaml(20)
+Available providers: default(0) git(10) git_old(11) yaml(20) env(30)
 Available checks   : before_all ci closure coffeelint common console_log csslint debugger gemfile_path go jshint jslint local merge_conflict migration nb_space php pry rails rspec_focus rubocop ruby ruby_symbol_hashrockets tabs whitespace
 Default   checks   : common rails
 Enabled   checks   : common rails
@@ -98,7 +98,7 @@ EXPECTED
     cli.execute.must_equal(true)
     $stderr.string.must_equal('')
     $stdout.string.gsub(/\s+\n/,"\n").must_equal(<<-EXPECTED)
-Available providers: default(0) git(10) git_old(11) yaml(20)
+Available providers: default(0) git(10) git_old(11) yaml(20) env(30)
 Available checks   : before_all ci closure coffeelint common console_log csslint debugger gemfile_path go jshint jslint local merge_conflict migration nb_space php pry rails rspec_focus rubocop ruby ruby_symbol_hashrockets tabs whitespace
 Default   checks   : common rails
 Enabled   checks   : common rails
@@ -120,7 +120,7 @@ EXPECTED
     cli.execute.must_equal(true)
     $stderr.string.must_equal('')
     $stdout.string.gsub(/\s+\n/,"\n").must_equal(<<-EXPECTED)
-Available providers: default(0) git(10) git_old(11) yaml(20)
+Available providers: default(0) git(10) git_old(11) yaml(20) env(30)
 Available checks   : before_all ci closure coffeelint common console_log csslint debugger gemfile_path go jshint jslint local merge_conflict migration nb_space php pry rails rspec_focus rubocop ruby ruby_symbol_hashrockets tabs whitespace
 Default   checks   : common rails
 Enabled   checks   : common rails


### PR DESCRIPTION
Added PreCommit::Checks::Plugin::ConfigFile to encapsulate standard
logic for specifying config file. Previously Rubocop used configuration
providers, JSHint used an environment variable or hardcoded file, and
coffeelint didn't allow a custom config file.

Now, the folling places will be checked for a config file.
- Config providers in priority order
- Plugin specified alternate location (Used by JSHint)

Adds the Env configuration provider, which will check
environment variables (JSHint manually did this previously).

Fixes #125
