### PR TITLE
Check .coffee files for console.log too

### DIFF
--- a/lib/plugins/pre_commit/checks/console_log.rb
+++ b/lib/plugins/pre_commit/checks/console_log.rb
@@ -5,7 +5,7 @@ module PreCommit
     class ConsoleLog < Grep
 
       def files_filter(staged_files)
-        staged_files.grep(/\.js$/)
+        staged_files.grep(/\.(js|coffee)$/)
       end
 
       def extra_grep


### PR DESCRIPTION
Can't see any reason not to do this: I was a bit disappointed when it didn't work out of the box for coffeescript. I can augment the tests if needed.
