### PR TITLE
Adds --force-exclusion option to rubocop CLI

### DIFF
--- a/lib/plugins/pre_commit/checks/rubocop.rb
+++ b/lib/plugins/pre_commit/checks/rubocop.rb
@@ -21,7 +21,7 @@ module PreCommit
         staged_files = staged_files.grep(/\.rb$/)
         return if staged_files.empty?
 
-        args = config_file_flag + staged_files
+        args = config_file_flag + ["--force-exclusion"] + staged_files
 
         success, captured = capture { ::Rubocop::CLI.new.run(args) == 0 }
         captured unless success


### PR DESCRIPTION
If this option is not passed rubocop will check the files in git stage even though they are in paths excluded in the rubocop config file.
