### PR TITLE
Allow logging individual check run times.

### DIFF
--- a/lib/pre-commit/runner.rb
+++ b/lib/pre-commit/runner.rb
@@ -41,8 +41,9 @@ module PreCommit
     def execute(list)
       list.map do |cmd|
         result = nil
+
         seconds = Benchmark.realtime do
-          cmd.new(pluginator, config, list).call(staged_files.dup)
+          result = cmd.new(pluginator, config, list).call(staged_files.dup)
         end
 
         puts "#{cmd} #{seconds*1000}ms" if debug


### PR DESCRIPTION
```
pre-commit[josh/time_check_run_time]% PRE_COMMIT_DEBUG=true git commit -v
PreCommit::Checks::Tabs 16.721ms
PreCommit::Checks::NbSpace 0.17200000000000001ms
PreCommit::Checks::Whitespace 6.819999999999999ms
PreCommit::Checks::MergeConflict 9.574ms
PreCommit::Checks::Debugger 10.395ms
PreCommit::Checks::Pry 8.187ms
PreCommit::Checks::Local 0.044ms
PreCommit::Checks::Jshint 52.336ms
PreCommit::Checks::ConsoleLog 0.033ms
PreCommit::Checks::Migration 0.048ms
```
