### PR TITLE
Prevent result of Cli#execute_run from being clobbered.

### DIFF
--- a/lib/pre-commit/cli.rb
+++ b/lib/pre-commit/cli.rb
@@ -33,7 +33,7 @@ module PreCommit
 
     def execute_run(*args)
       require 'pre-commit/runner'
-      PreCommit::Runner.new.run(*args) and puts "No failed checks."
+      PreCommit::Runner.new.run(*args).tap { |ok| puts "No failed checks." if ok }
     end
 
     def execute_install(key = nil, *args)


### PR DESCRIPTION
This fixes a problem where, currently, when you run `pre-commit run` from the command line, it always returns an exit code of `1`, which is really bad when you're using it, say, in a CI environment. 
