### PR TITLE
Closure_linter check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 bundler_args: ""
 before_install:
+  - sudo add-apt-repository ppa:fta/dev -y
   - sudo apt-get update
-  - sudo apt-get install -y nodejs php5
+  - sudo apt-get install -y nodejs php5 closure-linter
   - npm install -g coffeelint
   - rvm default do gem install execjs
   - git config --global user.name "Pre Commit"

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ These are the available checks:
 * jshint
 * js_lint
 * closure\_syntax\_check
+* closure\_linter (Check your JS using [closure linter tool](https://developers.google.com/closure/utilities/docs/linter_howto). Closure Linter must be installed)
 * php (Runs php -l on all staged files)
 * rspec_focus (Will check if you are about to check in a :focus in a spec file)
 * ruby_symbol_hashrockets (1.9 syntax. BAD :foo => "bar". GOOD foo: "bar")

--- a/lib/plugins/pre_commit/checks/closure_linter.rb
+++ b/lib/plugins/pre_commit/checks/closure_linter.rb
@@ -1,0 +1,22 @@
+require 'pre-commit/checks/plugin'
+
+module PreCommit
+  module Checks
+    class ClosureLinter < Plugin
+      def call(staged_files)
+        staged_files = staged_files.grep(/\.js$/)
+        return if staged_files.empty?
+
+        output = `gjslint --nojsdoc #{staged_files.join(" ")}`
+        return if output =~ /(\d*) files checked, no errors found(.*)/
+
+        output
+      end
+
+      def self.description
+        "Runs closure linter syntax check"
+      end
+
+    end
+  end
+end

--- a/test/unit/plugins/pre_commit/checks/closure_linter_test.rb
+++ b/test/unit/plugins/pre_commit/checks/closure_linter_test.rb
@@ -1,0 +1,19 @@
+require 'minitest_helper'
+require 'plugins/pre_commit/checks/closure_linter'
+
+describe PreCommit::Checks::ClosureLinter do
+  let(:check){ PreCommit::Checks::ClosureLinter.new(nil, nil, []) }
+
+  it "succeeds if nothing changed" do
+    check.call([]).must_equal nil
+  end
+
+  it "succeeds if only good changes" do
+    check.call([fixture_file('valid_file.js')]).must_equal nil
+  end
+
+  it "fails if file contains debugger" do
+    text = "Line 2, E:0010: Missing semicolon at end of line\nFound 2 errors"
+    check.call([fixture_file('bad_closure.js')]).must_include text
+  end
+end

--- a/test/unit/pre-commit/cli_test.rb
+++ b/test/unit/pre-commit/cli_test.rb
@@ -46,7 +46,7 @@ describe PreCommit::Cli do
     $stderr.string.must_equal('')
     $stdout.string.gsub(/\s+\n/,"\n").must_equal(<<-EXPECTED)
 Available providers: default(0) git(10) git_old(11) yaml(20) env(30)
-Available checks   : before_all ci closure coffeelint common console_log csslint debugger gemfile_path go jshint jslint json local merge_conflict migration nb_space pry rails rspec_focus rubocop ruby ruby_symbol_hashrockets scss_lint tabs whitespace yaml
+Available checks   : before_all ci closure closure_linter coffeelint common console_log csslint debugger gemfile_path go jshint jslint json local merge_conflict migration nb_space pry rails rspec_focus rubocop ruby ruby_symbol_hashrockets scss_lint tabs whitespace yaml
 Default   checks   : common rails
 Enabled   checks   : common rails
 Evaluated checks   : tabs nb_space whitespace merge_conflict debugger pry local jshint console_log migration
@@ -77,7 +77,7 @@ EXPECTED
     $stderr.string.must_equal('')
     $stdout.string.gsub(/\s+\n/,"\n").must_equal(<<-EXPECTED)
 Available providers: default(0) git(10) git_old(11) yaml(20) env(30)
-Available checks   : before_all ci closure coffeelint common console_log csslint debugger gemfile_path go jshint jslint json local merge_conflict migration nb_space pry rails rspec_focus rubocop ruby ruby_symbol_hashrockets scss_lint tabs whitespace yaml
+Available checks   : before_all ci closure closure_linter coffeelint common console_log csslint debugger gemfile_path go jshint jslint json local merge_conflict migration nb_space pry rails rspec_focus rubocop ruby ruby_symbol_hashrockets scss_lint tabs whitespace yaml
 Default   checks   : common rails
 Enabled   checks   : common rails
 Evaluated checks   : tabs nb_space merge_conflict debugger pry local jshint console_log migration
@@ -99,7 +99,7 @@ EXPECTED
     $stderr.string.must_equal('')
     $stdout.string.gsub(/\s+\n/,"\n").must_equal(<<-EXPECTED)
 Available providers: default(0) git(10) git_old(11) yaml(20) env(30)
-Available checks   : before_all ci closure coffeelint common console_log csslint debugger gemfile_path go jshint jslint json local merge_conflict migration nb_space pry rails rspec_focus rubocop ruby ruby_symbol_hashrockets scss_lint tabs whitespace yaml
+Available checks   : before_all ci closure closure_linter coffeelint common console_log csslint debugger gemfile_path go jshint jslint json local merge_conflict migration nb_space pry rails rspec_focus rubocop ruby ruby_symbol_hashrockets scss_lint tabs whitespace yaml
 Default   checks   : common rails
 Enabled   checks   : common rails
 Evaluated checks   : tabs nb_space merge_conflict debugger pry local jshint console_log migration
@@ -121,7 +121,7 @@ EXPECTED
     $stderr.string.must_equal('')
     $stdout.string.gsub(/\s+\n/,"\n").must_equal(<<-EXPECTED)
 Available providers: default(0) git(10) git_old(11) yaml(20) env(30)
-Available checks   : before_all ci closure coffeelint common console_log csslint debugger gemfile_path go jshint jslint json local merge_conflict migration nb_space pry rails rspec_focus rubocop ruby ruby_symbol_hashrockets scss_lint tabs whitespace yaml
+Available checks   : before_all ci closure closure_linter coffeelint common console_log csslint debugger gemfile_path go jshint jslint json local merge_conflict migration nb_space pry rails rspec_focus rubocop ruby ruby_symbol_hashrockets scss_lint tabs whitespace yaml
 Default   checks   : common rails
 Enabled   checks   : common rails
 Evaluated checks   : tabs nb_space whitespace merge_conflict debugger pry local jshint console_log migration

--- a/test/unit/pre-commit/list_evaluator_test.rb
+++ b/test/unit/pre-commit/list_evaluator_test.rb
@@ -22,7 +22,7 @@ describe PreCommit::ListEvaluator do
   it :list do
     subject.list.gsub(/\s+\n/,"\n").must_equal(<<-EXPECTED)
 Available providers: default(0)
-Available checks   : before_all ci closure coffeelint common console_log csslint debugger gemfile_path go jshint jslint json local merge_conflict migration nb_space pry rails rspec_focus rubocop ruby ruby_symbol_hashrockets scss_lint tabs whitespace yaml
+Available checks   : before_all ci closure closure_linter coffeelint common console_log csslint debugger gemfile_path go jshint jslint json local merge_conflict migration nb_space pry rails rspec_focus rubocop ruby ruby_symbol_hashrockets scss_lint tabs whitespace yaml
 Default   checks   :
 Enabled   checks   :
 Evaluated checks   :


### PR DESCRIPTION
I suggest connecting `pre-commit` and [`closure_linter`](https://developers.google.com/closure/utilities/docs/linter_howto). We use their guide in our project for JS codestyle, and it would be nice to do that automatically.

This implementation requires external install of `closure_linter` (which is available in ubuntu in the `universe` repo f.e.). I put a note about this fact in README.

Thanks.