### PR TITLE
With RVM use _current_ ruby and gemset, not _default_

### DIFF
--- a/templates/hooks/automatic
+++ b/templates/hooks/automatic
@@ -13,7 +13,9 @@ cmd=`git config pre-commit.ruby 2>/dev/null`
 if   test -n "${cmd}"
 then true
 elif which rvm   >/dev/null 2>/dev/null
-then cmd="rvm default do ruby"
+then
+  current_ruby=`rvm current`
+  cmd="rvm ${current_ruby} do ruby"
 elif which rbenv >/dev/null 2>/dev/null
 then cmd="rbenv exec ruby"
 else cmd="ruby"


### PR DESCRIPTION
I was getting errors, when trying to use rubocop in pre-commit, because it couldn't be found. But I had installed it in the current gemset. The problem was, that pre-commit was not using the _current_ gemset, but the _default_. This commit fixes that.