### PR TITLE
Adding rspec check for focus syntactic sugar

### DIFF
--- a/lib/plugins/pre_commit/checks/rspec_focus_sugar.rb
+++ b/lib/plugins/pre_commit/checks/rspec_focus_sugar.rb
@@ -1,0 +1,25 @@
+require 'pre-commit/checks/grep'
+
+module PreCommit
+  module Checks
+    class RspecFocusSugar < Grep
+
+      def files_filter(staged_files)
+        staged_files.grep(/_spec\.rb$/)
+      end
+
+      def message
+        ":syntactic sugar fdescribe|fcontext|fit for focus found in specs:"
+      end
+
+      def pattern
+        "(fdescribe|fcontext|fit).*(\"|').*(\"|').*do"
+      end
+
+      def self.description
+        "Finds ruby specs with syntactic sugar versions of focus: fdescribe|fcontext|fit."
+      end
+
+    end
+  end
+end

--- a/test/files/rspec_focus_sugar_bad_spec.rb
+++ b/test/files/rspec_focus_sugar_bad_spec.rb
@@ -1,0 +1,8 @@
+describe RspecFocusSugarChecks do
+  fcontext 'f prefixed to context' do
+    fdescribe 'f prefixed to describe' do
+      fit 'f prefixed to it' do
+      end
+    end
+  end
+end

--- a/test/files/rspec_focus_sugar_good_spec.rb
+++ b/test/files/rspec_focus_sugar_good_spec.rb
@@ -1,0 +1,10 @@
+describe FitModel do
+  it 'does not trigger the pre-commit focus with fit in description' do
+  end
+
+  it 'does not trigger the pre-commit focus with fdescribe in description' do
+  end
+
+  it 'does not trigger the pre-commit focus with fcontext in description' do
+  end
+end

--- a/test/unit/plugins/pre_commit/checks/rspec_focus_sugar_test.rb
+++ b/test/unit/plugins/pre_commit/checks/rspec_focus_sugar_test.rb
@@ -1,0 +1,28 @@
+require 'minitest_helper'
+require 'plugins/pre_commit/checks/rspec_focus_sugar'
+
+
+describe PreCommit::Checks::RspecFocusSugar do
+  let(:check){ PreCommit::Checks::RspecFocusSugar.new(nil, nil, []) }
+
+  it "succeeds if nothing changed" do
+    check.call([]).must_equal nil
+  end
+
+  it "succeeds on non-specs" do
+    check.call([fixture_file('bad-spec.rb')]).must_equal nil
+  end
+
+  it "succeeds if only good changes" do
+    check.call([fixture_file('rspec_focus_sugar_good_spec.rb')]).must_equal nil
+  end
+
+  it 'fails if focus specified on describe, context or example block using any valid syntax' do
+    check.call([fixture_file('rspec_focus_sugar_bad_spec.rb')]).to_s.must_equal("\
+:syntactic sugar fdescribe|fcontext|fit for focus found in specs:
+test/files/rspec_focus_sugar_bad_spec.rb:2:  fcontext 'f prefixed to context' do
+test/files/rspec_focus_sugar_bad_spec.rb:3:    fdescribe 'f prefixed to describe' do
+test/files/rspec_focus_sugar_bad_spec.rb:4:      fit 'f prefixed to it' do")
+  end
+
+end

--- a/test/unit/pre-commit/cli_test.rb
+++ b/test/unit/pre-commit/cli_test.rb
@@ -46,7 +46,7 @@ describe PreCommit::Cli do
     $stderr.string.must_equal('')
     $stdout.string.gsub(/\s+\n/,"\n").must_equal(<<-EXPECTED)
 Available providers: default(0) git(10) git_old(11) yaml(20) env(30)
-Available checks   : before_all ci closure coffeelint common console_log csslint debugger gemfile_path go jshint jslint json local merge_conflict migration nb_space pry rails rspec_focus rubocop ruby ruby_symbol_hashrockets scss_lint tabs whitespace yaml
+Available checks   : before_all ci closure coffeelint common console_log csslint debugger gemfile_path go jshint jslint json local merge_conflict migration nb_space pry rails rspec_focus rspec_focus_sugar rubocop ruby ruby_symbol_hashrockets scss_lint tabs whitespace yaml
 Default   checks   : common rails
 Enabled   checks   : common rails
 Evaluated checks   : tabs nb_space whitespace merge_conflict debugger pry local jshint console_log migration
@@ -77,7 +77,7 @@ EXPECTED
     $stderr.string.must_equal('')
     $stdout.string.gsub(/\s+\n/,"\n").must_equal(<<-EXPECTED)
 Available providers: default(0) git(10) git_old(11) yaml(20) env(30)
-Available checks   : before_all ci closure coffeelint common console_log csslint debugger gemfile_path go jshint jslint json local merge_conflict migration nb_space pry rails rspec_focus rubocop ruby ruby_symbol_hashrockets scss_lint tabs whitespace yaml
+Available checks   : before_all ci closure coffeelint common console_log csslint debugger gemfile_path go jshint jslint json local merge_conflict migration nb_space pry rails rspec_focus rspec_focus_sugar rubocop ruby ruby_symbol_hashrockets scss_lint tabs whitespace yaml
 Default   checks   : common rails
 Enabled   checks   : common rails
 Evaluated checks   : tabs nb_space merge_conflict debugger pry local jshint console_log migration
@@ -99,7 +99,7 @@ EXPECTED
     $stderr.string.must_equal('')
     $stdout.string.gsub(/\s+\n/,"\n").must_equal(<<-EXPECTED)
 Available providers: default(0) git(10) git_old(11) yaml(20) env(30)
-Available checks   : before_all ci closure coffeelint common console_log csslint debugger gemfile_path go jshint jslint json local merge_conflict migration nb_space pry rails rspec_focus rubocop ruby ruby_symbol_hashrockets scss_lint tabs whitespace yaml
+Available checks   : before_all ci closure coffeelint common console_log csslint debugger gemfile_path go jshint jslint json local merge_conflict migration nb_space pry rails rspec_focus rspec_focus_sugar rubocop ruby ruby_symbol_hashrockets scss_lint tabs whitespace yaml
 Default   checks   : common rails
 Enabled   checks   : common rails
 Evaluated checks   : tabs nb_space merge_conflict debugger pry local jshint console_log migration
@@ -121,7 +121,7 @@ EXPECTED
     $stderr.string.must_equal('')
     $stdout.string.gsub(/\s+\n/,"\n").must_equal(<<-EXPECTED)
 Available providers: default(0) git(10) git_old(11) yaml(20) env(30)
-Available checks   : before_all ci closure coffeelint common console_log csslint debugger gemfile_path go jshint jslint json local merge_conflict migration nb_space pry rails rspec_focus rubocop ruby ruby_symbol_hashrockets scss_lint tabs whitespace yaml
+Available checks   : before_all ci closure coffeelint common console_log csslint debugger gemfile_path go jshint jslint json local merge_conflict migration nb_space pry rails rspec_focus rspec_focus_sugar rubocop ruby ruby_symbol_hashrockets scss_lint tabs whitespace yaml
 Default   checks   : common rails
 Enabled   checks   : common rails
 Evaluated checks   : tabs nb_space whitespace merge_conflict debugger pry local jshint console_log migration

--- a/test/unit/pre-commit/list_evaluator_test.rb
+++ b/test/unit/pre-commit/list_evaluator_test.rb
@@ -22,7 +22,7 @@ describe PreCommit::ListEvaluator do
   it :list do
     subject.list.gsub(/\s+\n/,"\n").must_equal(<<-EXPECTED)
 Available providers: default(0)
-Available checks   : before_all ci closure coffeelint common console_log csslint debugger gemfile_path go jshint jslint json local merge_conflict migration nb_space pry rails rspec_focus rubocop ruby ruby_symbol_hashrockets scss_lint tabs whitespace yaml
+Available checks   : before_all ci closure coffeelint common console_log csslint debugger gemfile_path go jshint jslint json local merge_conflict migration nb_space pry rails rspec_focus rspec_focus_sugar rubocop ruby ruby_symbol_hashrockets scss_lint tabs whitespace yaml
 Default   checks   :
 Enabled   checks   :
 Evaluated checks   :


### PR DESCRIPTION
I always use the 'f' prefix for adding focus to my specs in rspec rather than :focus, so the existing check wasn't helping me.  I added this to help prevent me from adding focus to my team's specs.  

this commit fixes #205 
