### PR TITLE
RuboCop should check more than just .rb files. This commit fixes that problem.

### DIFF
--- a/lib/plugins/pre_commit/checks/rubocop.rb
+++ b/lib/plugins/pre_commit/checks/rubocop.rb
@@ -18,7 +18,24 @@ module PreCommit
       rescue LoadError => e
         $stderr.puts "Could not find rubocop: #{e}"
       else
-        staged_files = staged_files.grep(/\.rb$/)
+        allowed_files_regex = /\.gemspec\Z|
+                               \.podspec\Z|
+                               \.jbuilder\Z|
+                               \.rake\Z|
+                               \.opal\Z|
+                               \.rb\Z|
+                               Gemfile\Z|
+                               Rakefile\Z|
+                               Capfile\Z|
+                               Guardfile\Z|
+                               Podfile\Z|
+                               Thorfile\Z|
+                               Vagrantfile\Z|
+                               Berksfile\Z|
+                               Cheffile\Z|
+                               Vagabondfile\Z
+                              /x
+        staged_files = staged_files.grep(allowed_files_regex)
         return if staged_files.empty?
 
         args = config_file_flag + user_supplied_flags + ["--force-exclusion"] + staged_files

--- a/test/unit/plugins/pre_commit/checks/rubocop_test.rb
+++ b/test/unit/plugins/pre_commit/checks/rubocop_test.rb
@@ -25,6 +25,18 @@ describe PreCommit::Checks::Rubocop do
     # rubinius finds only 1 offense, all others find 2
     check.call([fixture_file('merge_conflict.rb')]).must_match(/1 file inspected, (\e\[31m)?[12] offenses? detected/)
   end
+  %w(.gemspec .podspec .jbuilder .rake .opal .rb).each do |extension|
+    it "runs checks on #{extension} files" do
+      check.call([fixture_file("test#{extension}")]).must_match(/Inspecting 1 file\n\n\n0 files inspected, no offenses detected\nNo such file or directory/)
+    end
+  end
+
+  %w(Gemfile Rakefile Capfile Guardfile Podfile Thorfile Vagrantfile
+     Berksfile Cheffile Vagabondfile).each do |file|
+    it "runs checks on #{file} file" do
+      check.call([fixture_file(file)]).must_match(/Inspecting 1 file\n\n\n0 files inspected, no offenses detected\nNo such file or directory/)
+    end
+  end
 
   describe 'with --fail-level=warn' do
     let(:flags) { '--fail-level=warn' }


### PR DESCRIPTION
RuboCop check was updated to forward following file types/files to the RuboCop:
.gemspec
.podspec
.jbuilder
.rake
.opal
.rb
Gemfile
Rakefile
Capfile
Guardfile
Podfile
Thorfile
Vagrantfile
Berksfile
Cheffile
Vagabondfile