### PR TITLE
Skip checking when staged files are empty

### DIFF
--- a/lib/plugins/pre_commit/checks/whitespace.rb
+++ b/lib/plugins/pre_commit/checks/whitespace.rb
@@ -23,6 +23,8 @@ module PreCommit
       end
 
       def call(staged_files)
+        return if staged_files.empty?
+
         errors = `git diff-index --check --cached HEAD -- #{files_string(staged_files)} 2>&1`
         return if $?.success?
 

--- a/test/unit/plugins/pre_commit/checks/whitespace_test.rb
+++ b/test/unit/plugins/pre_commit/checks/whitespace_test.rb
@@ -12,16 +12,28 @@ describe PreCommit::Checks::Whitespace do
   let(:check){ PreCommit::Checks::Whitespace.new(nil, nil, []) }
 
   it "succeeds if nothing changed" do
-    check.call([]).must_equal nil
+    check.call(['a']).must_equal nil
   end
 
   it "succeeds if only good changes" do
     `echo aaa > b && git add b`
-    check.call([]).must_equal nil
+    check.call(['a', 'b']).must_equal nil
   end
 
-  it "fails on bad changes" do
-    `echo '   ' > b && git add b`
-    check.call([]).must_equal "b:1: trailing whitespace.\n+   \nb:1: new blank line at EOF.\n"
+  describe 'staged bad changes' do
+    it "fails on bad changes" do
+      `echo '   ' > b && git add b`
+      check.call(['a', 'b']).must_equal "b:1: trailing whitespace.\n+   \nb:1: new blank line at EOF.\n"
+    end
+
+    it "succeeds if the target files don't have bad changes" do
+      `echo '   ' > b && git add b`
+      check.call(['a']).must_equal nil
+    end
+
+    it "succeeds if no target files" do
+      `echo '   ' > b && git add b`
+      check.call([]).must_equal nil
+    end
   end
 end


### PR DESCRIPTION
I think it's better that skip checking when "staged_files" is empty array.

```
# If staged_files is empty, following git command execute
# So every staged files are checked even if they are written in .pre_commit.ignore
git diff-index --check --cached HEAD --  2>&1
```