### PR TITLE
Add config.ru to allowed files for rubocop

### DIFF
--- a/lib/plugins/pre_commit/checks/rubocop.rb
+++ b/lib/plugins/pre_commit/checks/rubocop.rb
@@ -24,6 +24,7 @@ module PreCommit
                                \.rake\Z|
                                \.opal\Z|
                                \.rb\Z|
+                               config\.ru\Z|
                                Gemfile\Z|
                                Rakefile\Z|
                                Capfile\Z|


### PR DESCRIPTION
Rubocop 0.31.0 now checks config.ru by default