### PR TITLE
Add /usr/local/{s?}bin to PATH for GitHub for Mac

### DIFF
--- a/templates/hooks/automatic
+++ b/templates/hooks/automatic
@@ -10,7 +10,7 @@
 #
 
 # This is a work-around to get GitHub for Mac to be able to run `node` commands
-# http://stackoverflow.com/questions/12881975/git-pre-commit-hook-failing-in-github-for-mac-works-on-command-line
+# https://stackoverflow.com/questions/12881975/git-pre-commit-hook-failing-in-github-for-mac-works-on-command-line
 PATH=$PATH:/usr/local/bin:/usr/local/sbin
 
 

--- a/templates/hooks/automatic
+++ b/templates/hooks/automatic
@@ -9,6 +9,11 @@
 #     pre-commit install --manual
 #
 
+# This is a work-around to get GitHub for Mac to be able to run `node` commands
+# http://stackoverflow.com/questions/12881975/git-pre-commit-hook-failing-in-github-for-mac-works-on-command-line
+PATH=$PATH:/usr/local/bin:/usr/local/sbin
+
+
 cmd=`git config pre-commit.ruby 2>/dev/null`
 if   test -n "${cmd}"
 then true


### PR DESCRIPTION
This will allow GitHub for Mac to use binaries like `node` despite running without PATH specified in your shell config.