### PR TITLE
Filter Rubocop check files.

### DIFF
--- a/test/unit/plugins/pre_commit/checks/rubocop_test.rb
+++ b/test/unit/plugins/pre_commit/checks/rubocop_test.rb
@@ -25,16 +25,21 @@ describe PreCommit::Checks::Rubocop do
     # rubinius finds only 1 offense, all others find 2
     check.call([fixture_file('merge_conflict.rb')]).must_match(/1 file inspected, (\e\[31m)?[12] offenses? detected/)
   end
-  %w(.gemspec .podspec .jbuilder .rake .opal .rb).each do |extension|
-    it "runs checks on #{extension} files" do
-      check.call([fixture_file("test#{extension}")]).must_match(/Inspecting 1 file\n\n\n0 files inspected, no offenses detected\nNo such file or directory/)
+
+  [".gemspec", ".jbuilder", ".opal", ".podspec", ".rake", ".rb"].each do |ext|
+    it "Runs checks on #{ext} files" do
+      file = fixture_file("test#{ext}")
+      check.filter_staged_files([file]).must_include(file)
     end
   end
 
-  %w(Gemfile Rakefile Capfile Guardfile Podfile Thorfile Vagrantfile
-     Berksfile Cheffile Vagabondfile).each do |file|
-    it "runs checks on #{file} file" do
-      check.call([fixture_file(file)]).must_match(/Inspecting 1 file\n\n\n0 files inspected, no offenses detected\nNo such file or directory/)
+  [
+    "Berksfile", "Capfile", "Cheffile", "Gemfile", "Guardfile", "Podfile",
+    "Rakefile", "Thorfile", "Vagabondfile", "Vagrantfile"
+  ].each do |filename|
+    it "Runs checks on #{filename}" do
+      file = fixture_file("Gemfile")
+      check.filter_staged_files([file]).must_include(file)
     end
   end
 


### PR DESCRIPTION
Rubocop keeps changing functionality -- exit codes, output, method signatures. So, instead of checking for exactly how Rubocop is behaving, we're just testing our file filtering logic.