### PR TITLE
Relax error message checking on third party libraries.

### DIFF
--- a/test/unit/plugins/pre_commit/checks/coffeelint_test.rb
+++ b/test/unit/plugins/pre_commit/checks/coffeelint_test.rb
@@ -19,12 +19,6 @@ describe PreCommit::Checks::Coffeelint do
   end
 
   it "fails for bad formatted code" do
-    check.call([fixture_file("bad.coffee")]).must_equal <<-ERROR
-  ✗ test/files/bad.coffee
-     ✗ #1: Class names should be camel cased. class name: helloWorld.
-
-✗ Lint! » 1 error and 0 warnings in 1 file
-
-ERROR
+    check.call([fixture_file("bad.coffee")]).must_match(/camel.*case/i)
   end
 end unless `which coffeelint 2>/dev/null`.empty?


### PR DESCRIPTION
Coffeelint keeps changing the specific wording of its error messages. The exact wording is not what we care about and it will not affect the functionality of our project.

We just care about exit codes and output in general, not strict adherence to a contract.