### PR TITLE
Change directory to the root of the git repository before doing any real work

### DIFF
--- a/bin/pre-commit
+++ b/bin/pre-commit
@@ -2,8 +2,9 @@
 
 require 'pre-commit/cli'
 
-if !File.exists?(".git")
-  abort "No .git directory found."
-end
+# Change directory to the root of the git repository.
+repo_root = `git rev-parse --show-toplevel`.strip
+abort "No .git directory found." unless File.directory?(repo_root)
+Dir.chdir repo_root
 
 PreCommit::Cli.new(*ARGV).execute or exit 1


### PR DESCRIPTION
This is better than walking upwards until finding a .git directory as
some people configure their .git directories to go in different places, see
http://stackoverflow.com/a/22081487.