### PR TITLE
Only lint specific extensions for Rubocop.

### DIFF
--- a/lib/plugins/pre_commit/checks/rubocop.rb
+++ b/lib/plugins/pre_commit/checks/rubocop.rb
@@ -6,7 +6,7 @@ module PreCommit
     class Rubocop < Plugin
 
       WHITELIST = [
-        ".gemspec", ".jbuilder", ".opal", ".podspec", ".rake", ".rb",
+        "\\.gemspec", "\\.jbuilder", "\\.opal", "\\.podspec", "\\.rake", "\\.rb",
         "Berksfile", "Capfile", "Cheffile", "Gemfile", "Guardfile", "Podfile",
         "Rakefile", "Thorfile", "Vagabondfile", "Vagrantfile"
       ]

--- a/test/unit/plugins/pre_commit/checks/rubocop_test.rb
+++ b/test/unit/plugins/pre_commit/checks/rubocop_test.rb
@@ -43,6 +43,11 @@ describe PreCommit::Checks::Rubocop do
     end
   end
 
+  it "ignores erb files" do
+    file = fixture_file("test.erb")
+    check.filter_staged_files([file]).wont_include(file)
+  end
+
   describe 'with --fail-level=warn' do
     let(:flags) { '--fail-level=warn' }
 


### PR DESCRIPTION
We were not escaping the `.` correctly when looking for a specific extension. This fixes it.

Just for a small context behind this fix, we have files named like `script.coffee.erb` and rubocop was trying to parse those files when it was not supposed to.

Let me know if the test is on the wrong location and where should I put it in case that's true.