### PR TITLE
Move all development dependencies into one place.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,13 @@ source "https://rubygems.org"
 gemspec
 
 group :development do
+  gem "guard", "~> 2.0"
+  gem "guard-minitest", "~> 2.0"
+  gem "minitest", "~> 4.0"
+  gem "minitest-reporters", "~> 0"
+  gem "rake", "~> 10.0"
+  gem "rubocop", "~> 0.25"
+
   # checks that do not have to be enabled
   gem "execjs"
   gem "scss-lint"

--- a/pre-commit.gemspec
+++ b/pre-commit.gemspec
@@ -29,13 +29,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency('pluginator', '~> 1.1')
 
-  s.add_development_dependency('guard', '~> 2.0')
-  s.add_development_dependency('guard-minitest', '~> 2.0')
-  s.add_development_dependency('minitest', '~> 4.0')
-  s.add_development_dependency('minitest-reporters', '~> 0')
-  s.add_development_dependency('rake', '~> 10.0')
-  s.add_development_dependency('rubocop', '~> 0.25')
-
   if s.respond_to? :specification_version then
     s.specification_version = 3
   end


### PR DESCRIPTION
I'm not sure whether `.gemspec` is better, or `Gemfile` is better. We're using Bundler's platform options like `:platforms => [:mri_20]` so I'm moving them all into `Gemfile`. If that is not correct, we can change it.