### PR TITLE
Warning on your own configuration file

### DIFF
--- a/lib/plugins/pre_commit/checks/yaml.rb
+++ b/lib/plugins/pre_commit/checks/yaml.rb
@@ -25,7 +25,7 @@ module PreCommit
       end
 
       def safe_load_file(file)
-        YAML.safe_load(File.read(file), [], [], true, file)
+        YAML.safe_load(File.read(file), [::Symbol], [], true, file)
 
         nil
       rescue Psych::DisallowedClass


### PR DESCRIPTION
```bash
Warning: Skipping 'config/pre_commit.yml' because it contains serialized ruby objects.
```

YAML.safe_load [does not support symbols](https://github.com/dtao/safe_yaml#supported-types). Your call to YAML.safe_load should allow them, like this:

```ruby
YAML.safe_load(File.read(file), [Symbol], [], true, file)
```