### PR TITLE
Removing symlinks from the repo.

### DIFF
--- a/lib/pre-commit/installer.rb
+++ b/lib/pre-commit/installer.rb
@@ -2,7 +2,6 @@ require 'fileutils'
 require 'pre-commit/configuration'
 
 module PreCommit
-
   class Installer
 
     TARGET_GIT_PATH = '.git'
@@ -12,7 +11,7 @@ module PreCommit
     attr_reader :key
 
     def initialize(key = nil)
-      @key = key || "default"
+      @key = key || "automatic"
     end
 
     def hook
@@ -42,8 +41,6 @@ module PreCommit
         false
       end
     end
-
-  private
 
     def templates
       return @templates if @templates

--- a/templates/hooks/default
+++ b/templates/hooks/default
@@ -1,1 +1,0 @@
-automatic

--- a/templates/hooks/simple
+++ b/templates/hooks/simple
@@ -1,0 +1,14 @@
+#!/usr/bin/env ruby
+
+# This hook has a focus on simplicity.
+# This hook puts the burden on you to set up your environment properly.
+#
+# If you would like `pre-commit` to attempt to setup your environment for you
+# before the checks run, you can install the automatic environment hook using:
+#
+#     pre-commit install --automatic
+#
+
+require 'pre-commit'
+
+PreCommit.run

--- a/test/unit/pre-commit/cli_test.rb
+++ b/test/unit/pre-commit/cli_test.rb
@@ -37,7 +37,7 @@ describe PreCommit::Cli do
     cli = subject.new('install')
     cli.execute.must_equal(true)
     $stderr.string.must_equal('')
-    $stdout.string.must_match(/Installed .*\/templates\/hooks\/default to .*\n/)
+    $stdout.string.must_match(/Installed .*\/templates\/hooks\/automatic to .*\n/)
   end
 
   it "lists configuration" do

--- a/test/unit/pre-commit/installer_test.rb
+++ b/test/unit/pre-commit/installer_test.rb
@@ -18,15 +18,18 @@ describe PreCommit::Installer do
   end
 
   subject { PreCommit::Installer }
+  let(:automatic_hook_contents) { File.read(subject.new.templates["automatic"]) }
 
   it "intalls the hook" do
     installer = subject.new
     File.exists?(installer.target).must_equal false
+
     installer.install.must_equal(true)
     File.exists?(installer.target).must_equal true
-    File.read(installer.target).must_equal File.read(installer.send(:templates)["default"])
+    File.read(installer.target).must_equal automatic_hook_contents
+
     $stderr.string.must_equal('')
-    $stdout.string.must_match(/Installed .*\/templates\/hooks\/default to #{installer.target}\n/)
+    $stdout.string.must_match(/Installed .*\/templates\/hooks\/automatic to #{installer.target}\n/)
   end
 
   it "installs other hook templates" do
@@ -39,12 +42,14 @@ describe PreCommit::Installer do
     $stdout.string.must_match(/Installed .*\/templates\/hooks\/manual to #{installer.target}\n/)
   end
 
-  it "installs the default hook when passed --automatic" do
+  it "installs the automatic hook when passed --automatic" do
     installer = subject.new('--automatic')
     File.exists?(installer.target).must_equal false
+
     installer.install.must_equal(true)
     File.exists?(installer.target).must_equal true
-    File.read(installer.target).must_equal File.read(installer.send(:templates)["default"])
+    File.read(installer.target).must_equal automatic_hook_contents
+
     $stderr.string.must_equal('')
     $stdout.string.must_match(/Installed .*\/templates\/hooks\/automatic to #{installer.target}\n/)
   end


### PR DESCRIPTION
On some systems, installing the gem does not put all of the symlinks
in place properly. Instead of using a symlink to determine which hook
is the default hook, we set the default value in Ruby instead.

closes #243 