### PR TITLE
Revert "The binary check handles unicode source files."

### DIFF
--- a/lib/pre-commit/utils/staged_files.rb
+++ b/lib/pre-commit/utils/staged_files.rb
@@ -35,8 +35,8 @@ module PreCommit
       def binary?(file)
         bytes = File.stat(file).blksize.to_i
         bytes = 4096 if bytes > 4096
-        s = (File.read(file, bytes) || "")
-        s = s.encode('US-ASCII', :undef => :replace).split(//)
+        s = (File.read(file, bytes) || "").split(//)
+
         ((s.size - s.grep(" ".."~").size) / s.size.to_f) > 0.30
       end
 

--- a/test/unit/pre-commit/utils/staged_files_test.rb
+++ b/test/unit/pre-commit/utils/staged_files_test.rb
@@ -25,17 +25,6 @@ describe PreCommit::Utils::StagedFiles do
       subject.staged_files.must_equal([])
     end
 
-    it "allows files with unicode characters" do
-      write("unicode_source.rb", <<-RUBY)
-# コメント
-def sample
-  # comment
-  # comment
-end
-      RUBY
-      sh "git add -A"
-      subject.staged_files.must_equal(["unicode_source.rb"])
-    end
 
     it "does not blow up on zero size files" do
       write("no_contents", "")


### PR DESCRIPTION
This reverts commit 4af9b52190c04bb430821d857ebeda8bb064b633.

cc: @jfly