### PR TITLE
Be sure to set the post_install_message

### DIFF
--- a/pre-commit.gemspec
+++ b/pre-commit.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.license = 'Apache 2.0'
   s.summary = "A slightly better git pre-commit hook"
   s.description = "A git pre-commit hook written in ruby with a few more tricks up its sleeve"
-  s.post_install_message == <<-EOF
+  s.post_install_message = <<-EOF
     Thank you for installing pre-commit!
     Install the hook in each git repo you want to scan using:
 


### PR DESCRIPTION
Currently released gems do not show the `post_install_message` written in the gemspec because the message is not actually assigned, but...