### PR TITLE
⚠ Ruby Warnings

### DIFF
--- a/lib/plugins/pre_commit/configuration/providers/yaml.rb
+++ b/lib/plugins/pre_commit/configuration/providers/yaml.rb
@@ -25,12 +25,13 @@ module PreCommit
       private
 
         def config
-          return @config if @config
-          @config = {}
-          @config.merge!(read_config(system_file))
-          @config.merge!(read_config(global_file))
-          @config.merge!(read_config(local_file))
-          @config
+          @config ||= begin
+            config = {}
+            config.merge!(read_config(system_file))
+            config.merge!(read_config(global_file))
+            config.merge!(read_config(local_file))
+            config
+          end
         end
 
         def read_config(path)

--- a/lib/pre-commit/checks/grep.rb
+++ b/lib/pre-commit/checks/grep.rb
@@ -5,6 +5,14 @@ require 'pre-commit/line'
 module PreCommit
   module Checks
     class Grep < Shell
+      def initialize(*)
+        super
+
+        @extra_grep = nil
+        @message = nil
+        @pattern = nil
+      end
+
       class PaternNotSet < StandardError
         def message
           "Please define 'pattern' method."

--- a/lib/pre-commit/configuration/providers.rb
+++ b/lib/pre-commit/configuration/providers.rb
@@ -43,9 +43,7 @@ module PreCommit
       end
 
       def find_update_plugin(plugin_name)
-        plugin = plugins.detect{|plugin| class2string(class2name(plugin.class)) == plugin_name.to_s}
-        raise PluginNotFound.new("Plugin not found for #{plugin_name}.") unless plugin
-        plugin
+        plugins.detect{|plugin| class2string(class2name(plugin.class)) == plugin_name.to_s} || raise(PluginNotFound.new("Plugin not found for #{plugin_name}."))
       end
 
     end

--- a/lib/pre-commit/installer.rb
+++ b/lib/pre-commit/installer.rb
@@ -43,14 +43,14 @@ module PreCommit
     end
 
     def templates
-      return @templates if @templates
-      pattern = File.join(TEMPLATE_DIR, "*")
+      @templates ||= begin
+        pattern = File.join(TEMPLATE_DIR, "*")
 
-      @templates =
-      Dir.glob(pattern).inject({}) do |hash, file|
-        key = file.match(/\/([^\/]+?)$/)[1]
-        hash[key] = file
-        hash
+        Dir.glob(pattern).inject({}) do |hash, file|
+          key = file.match(/\/([^\/]+?)$/)[1]
+          hash[key] = file
+          hash
+        end
       end
     end
 

--- a/lib/pre-commit/utils/git_conversions.rb
+++ b/lib/pre-commit/utils/git_conversions.rb
@@ -19,7 +19,7 @@ module PreCommit
       end
 
       def str2arr(string)
-        string.split(/, ?/).map{|string| str_symbolize(string.chomp.strip) }
+        string.split(/, ?/).map{|s| str_symbolize(s.chomp.strip) }
       end
 
       def str_symbolize(string)

--- a/lib/pre-commit/utils/staged_files.rb
+++ b/lib/pre-commit/utils/staged_files.rb
@@ -42,7 +42,7 @@ module PreCommit
 
       def filter_files(files)
         files.reject do |file|
-          !File.exists?(file) ||
+          !File.exist?(file) ||
           File.directory?(file) ||
           (
             size = File.size(file)

--- a/test/unit/plugins/pre_commit/checks/ruby_symbol_hashrockets_test.rb
+++ b/test/unit/plugins/pre_commit/checks/ruby_symbol_hashrockets_test.rb
@@ -13,7 +13,7 @@ describe PreCommit::Checks::RubySymbolHashrockets do
   end
 
   it "fails with invalid" do
-    result = check.call([fixture_file('wrong_hashrockets.rb')]).to_s.must_equal("\
+    check.call([fixture_file('wrong_hashrockets.rb')]).to_s.must_equal("\
 detected :symbol => value hashrocket:
 test/files/wrong_hashrockets.rb:3:gem 'foo', :ref => 'v2.6.0'
 test/files/wrong_hashrockets.rb:5:{ :@test => \"foo_bar\" }

--- a/test/unit/pre-commit/installer_test.rb
+++ b/test/unit/pre-commit/installer_test.rb
@@ -22,10 +22,10 @@ describe PreCommit::Installer do
 
   it "intalls the hook" do
     installer = subject.new
-    File.exists?(installer.target).must_equal false
+    File.exist?(installer.target).must_equal false
 
     installer.install.must_equal(true)
-    File.exists?(installer.target).must_equal true
+    File.exist?(installer.target).must_equal true
     File.read(installer.target).must_equal automatic_hook_contents
 
     $stderr.string.must_equal('')
@@ -34,9 +34,9 @@ describe PreCommit::Installer do
 
   it "installs other hook templates" do
     installer = subject.new('--manual')
-    File.exists?(installer.target).must_equal false
+    File.exist?(installer.target).must_equal false
     installer.install.must_equal(true)
-    File.exists?(installer.target).must_equal true
+    File.exist?(installer.target).must_equal true
     File.read(installer.target).must_equal File.read(installer.send(:templates)["manual"])
     $stderr.string.must_equal('')
     $stdout.string.must_match(/Installed .*\/templates\/hooks\/manual to #{installer.target}\n/)
@@ -44,10 +44,10 @@ describe PreCommit::Installer do
 
   it "installs the automatic hook when passed --automatic" do
     installer = subject.new('--automatic')
-    File.exists?(installer.target).must_equal false
+    File.exist?(installer.target).must_equal false
 
     installer.install.must_equal(true)
-    File.exists?(installer.target).must_equal true
+    File.exist?(installer.target).must_equal true
     File.read(installer.target).must_equal automatic_hook_contents
 
     $stderr.string.must_equal('')
@@ -56,7 +56,7 @@ describe PreCommit::Installer do
 
   it "handles missing templates" do
     installer = subject.new('--not-found')
-    File.exists?(installer.target).must_equal false
+    File.exist?(installer.target).must_equal false
     installer.install.must_equal(false)
     $stderr.string.must_match(/Could not find template/)
     $stdout.string.must_equal('')

--- a/test/unit/pre-commit/list_evaluator_test.rb
+++ b/test/unit/pre-commit/list_evaluator_test.rb
@@ -33,13 +33,13 @@ EXPECTED
   end
 
   it "plugins have includes" do
-    list = subject.send(:format_plugin, "ruby", "6", configuration.pluginator.find_check(:ruby)).must_equal([
+    subject.send(:format_plugin, "ruby", "6", configuration.pluginator.find_check(:ruby)).must_equal([
       "  ruby : Plugins common for ruby.",
       "       - includes: pry local",
     ])
   end
   it "plugins have excludes" do
-    list = subject.send(:format_plugin, "rubocop", "7", configuration.pluginator.find_check(:rubocop)).must_equal([
+    subject.send(:format_plugin, "rubocop", "7", configuration.pluginator.find_check(:rubocop)).must_equal([
       "rubocop : Runs rubocop to detect errors.",
       "        - excludes: ruby_symbol_hashrocket",
     ])


### PR DESCRIPTION
Here are fixes for Ruby warnings we see when we run the whole tests with `RUBYOPT='-w'` option.