### PR TITLE
Add missing require plugin line in go_fmt plugin

### DIFF
--- a/lib/plugins/pre_commit/checks/go_fmt.rb
+++ b/lib/plugins/pre_commit/checks/go_fmt.rb
@@ -1,3 +1,5 @@
+require 'pre-commit/checks/plugin'
+
 module PreCommit
   module Checks
     class GoFmt < Plugin


### PR DESCRIPTION
Problem was found in #258, but not related to the issue - @jonatanklosko this should fix your problem

I used:
```ruby
puts Dir["lib/plugins/pre_commit/checks/**/*.rb"].map{|n| 
  n unless File.readlines(n).any?{|l| l=~%r{pre-commit/checks/} } 
}.compact
```
to confirm it's the only file that missed the require.