### PR TITLE
Do not run pre-commit checks on images

### DIFF
--- a/lib/pre-commit/utils/staged_files.rb
+++ b/lib/pre-commit/utils/staged_files.rb
@@ -7,11 +7,16 @@ module PreCommit
     module StagedFiles
       include PreCommit::Configuration::TopLevel
 
-      BINARIES = [".img", ".iso", ".dmg"].freeze
-      IMAGES = [".jpg", ".jpeg", ".png", ".gif"].freeze
+      BINARIES = [
+        ".dmg", ".gz", ".img", ".iso", ".rar", ".tar", ".xz", ".zip"
+      ].freeze
+      IMAGES = [".gif", ".ico", ".jpeg", ".jpg", ".pdf", ".png"].freeze
       IGNORED_EXTENSIONS = BINARIES + IMAGES
 
-      SOURCE_FILES = [".rb"].freeze
+      SOURCE_FILES = [
+        ".coffee", ".css", ".erb", ".feature", ".html", ".js", ".json",
+        ".liquid", ".md", ".rb", ".sass", ".scss", ".slim", ".yml"
+      ].freeze
 
       def set_staged_files(*args)
         case args[0].to_s

--- a/lib/pre-commit/utils/staged_files.rb
+++ b/lib/pre-commit/utils/staged_files.rb
@@ -1,9 +1,18 @@
-require "pre-commit/configuration/top_level"
+# frozen-string-literal: true
+
+require 'pre-commit/configuration/top_level'
 
 module PreCommit
   module Utils
     module StagedFiles
       include PreCommit::Configuration::TopLevel
+
+      BINARIES = [".img", ".iso", ".dmg"].freeze
+      DOCUMENTS = [".md"].freeze
+      IMAGES = [".jpg", ".jpeg", ".png", ".gif"].freeze
+      IGNORED_EXTENSIONS = BINARIES + DOCUMENTS + IMAGES
+
+      SOURCE_FILES = [".rb"].freeze
 
       def set_staged_files(*args)
         case args[0].to_s
@@ -30,6 +39,31 @@ module PreCommit
         @staged_files = filter_files(staged_from_git_all)
       end
 
+      # Definitely include this file in the checks.
+      def source_file?(filename)
+        SOURCE_FILES.include?(File.extname(filename))
+      end
+
+      # Try to bail out quickly based on filename.
+      #
+      # If the extension is `.jpg` this is likely not a source code file.
+      # So let's not waste time checking to see if it's "binary" (as best we
+      # can guess) and let's not run any checks on it.
+      def ignore_extension?(filename)
+        IGNORED_EXTENSIONS.include?(File.extname(filename))
+      end
+
+      # Make a best guess to determine if this is a binary file.
+      # This is not an exact science ;)
+      def appears_binary?(filename)
+        size = File.size(filename)
+        size > 1_000_000 || (size > 20 && binary?(filename))
+      end
+
+      def repo_ignored?(filename)
+        repo_ignores.any? { |ignore| File.fnmatch?(ignore, filename) }
+      end
+
     private
       # from https://github.com/djberg96/ptools/blob/master/lib/ptools.rb#L90
       def binary?(file)
@@ -41,14 +75,16 @@ module PreCommit
       end
 
       def filter_files(files)
-        files.reject do |file|
-          !File.exist?(file) ||
-          File.directory?(file) ||
-          (
-            size = File.size(file)
-            size > 1_000_000 || (size > 20 && binary?(file))
-          ) ||
-          repo_ignores.any? { |ignore| File.fnmatch?(ignore, file) }
+        first_pass = files
+          .reject { |file| repo_ignored?(file) }
+          .reject { |file| ignore_extension?(file) }
+          .reject { |file| File.directory?(file) }
+          .select { |file| File.exists?(file) }
+
+        # If it's a source file, definitely check it.
+        # Otherwise, attempt to guess if the file is binary or not.
+        first_pass.select do |file|
+          source_file?(file) || !appears_binary?(file)
         end
       end
 

--- a/lib/pre-commit/utils/staged_files.rb
+++ b/lib/pre-commit/utils/staged_files.rb
@@ -74,11 +74,12 @@ module PreCommit
       end
 
       def filter_files(files)
-        first_pass = files
-          .reject { |file| repo_ignored?(file) }
-          .reject { |file| ignore_extension?(file) }
-          .reject { |file| File.directory?(file) }
-          .select { |file| File.exists?(file) }
+        first_pass = files.reject do |file|
+          repo_ignored?(file) ||
+          ignore_extension?(file) ||
+          File.directory?(file) ||
+          !File.exists?(file)
+        end
 
         # If it's a source file, definitely check it.
         # Otherwise, attempt to guess if the file is binary or not.

--- a/lib/pre-commit/utils/staged_files.rb
+++ b/lib/pre-commit/utils/staged_files.rb
@@ -8,9 +8,8 @@ module PreCommit
       include PreCommit::Configuration::TopLevel
 
       BINARIES = [".img", ".iso", ".dmg"].freeze
-      DOCUMENTS = [".md"].freeze
       IMAGES = [".jpg", ".jpeg", ".png", ".gif"].freeze
-      IGNORED_EXTENSIONS = BINARIES + DOCUMENTS + IMAGES
+      IGNORED_EXTENSIONS = BINARIES + IMAGES
 
       SOURCE_FILES = [".rb"].freeze
 

--- a/pre-commit.gemspec
+++ b/pre-commit.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency('pluginator', '~> 1.5')
 
+  s.add_development_dependency('benchmark-ips')
   s.add_development_dependency('minitest', '~> 4.0')
   s.add_development_dependency('minitest-reporters', '~> 0')
   s.add_development_dependency('rake', '~> 10.0')

--- a/script/benchmark/staged_files.rb
+++ b/script/benchmark/staged_files.rb
@@ -1,0 +1,60 @@
+require 'benchmark/ips'
+require 'pre-commit/utils/staged_files'
+
+class Subject
+  include PreCommit::Utils::StagedFiles
+
+  def filter_files1(files)
+    first_pass = files
+      .reject { |file| repo_ignored?(file) }
+      .reject { |file| ignore_extension?(file) }
+      .reject { |file| File.directory?(file) }
+      .select { |file| File.exists?(file) }
+
+    # If it's a source file, definitely check it.
+    # Otherwise, attempt to guess if the file is binary or not.
+    first_pass.select do |file|
+      source_file?(file) || !appears_binary?(file)
+    end
+  end
+
+  def filter_files2(files)
+    first_pass = files.lazy
+      .reject { |file| repo_ignored?(file) }
+      .reject { |file| ignore_extension?(file) }
+      .reject { |file| File.directory?(file) }
+      .select { |file| File.exists?(file) }
+
+    # If it's a source file, definitely check it.
+    # Otherwise, attempt to guess if the file is binary or not.
+    first_pass.select do |file|
+      source_file?(file) || !appears_binary?(file)
+    end
+  end
+
+  def filter_files3(files)
+    first_pass = files.reject do |file|
+      repo_ignored?(file) ||
+      ignore_extension?(file) ||
+      File.directory?(file) ||
+      !File.exists?(file)
+    end
+
+    # If it's a source file, definitely check it.
+    # Otherwise, attempt to guess if the file is binary or not.
+    first_pass.select do |file|
+      source_file?(file) || !appears_binary?(file)
+    end
+  end
+end
+
+files = Dir['lib/**/*']
+subject = Subject.new
+
+Benchmark.ips do |x|
+  x.report('filter files 1') { subject.filter_files1(files) }
+  x.report('filter files 2') { subject.filter_files2(files).to_a }
+  x.report('filter files 3') { subject.filter_files3(files) }
+
+  x.compare!
+end

--- a/test/files/valid_file.rb
+++ b/test/files/valid_file.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 # class docs for rubocop
 class ValidFile
   # Comments with the word: debugger should be allowed

--- a/test/unit/pre-commit/utils/staged_files_test.rb
+++ b/test/unit/pre-commit/utils/staged_files_test.rb
@@ -20,11 +20,16 @@ describe PreCommit::Utils::StagedFiles do
     end
 
     it "filters out binary files" do
-      write("test.rb", (1..50).map(&:chr).join)
+      write("test", (1..50).map(&:chr).join)
       sh "git add -A"
       subject.staged_files.must_equal([])
     end
 
+    it "quick-filters out images based on extension" do
+      write("foo.jpg", "not an image")
+      sh "git add -A"
+      subject.staged_files.must_equal([])
+    end
 
     it "does not blow up on zero size files" do
       write("no_contents", "")
@@ -46,6 +51,26 @@ describe PreCommit::Utils::StagedFiles do
     end
 
   end # :staged_files
+
+  describe "source file" do
+    it "always treats Ruby files as source files" do
+      subject.source_file?("foo.rb").must_equal(true)
+    end
+  end
+
+  describe "ignore extension" do
+    it "ignores images" do
+      subject.ignore_extension?("foo.jpg").must_equal(true)
+    end
+
+    it "treats ordinary source code extensions as source files" do
+      subject.ignore_extension?("foo.rb").must_equal(false)
+    end
+
+    it "treats disk images as non-source files" do
+      subject.ignore_extension?("foo.dmg").must_equal(true)
+    end
+  end
 
   describe :repo_ignores do
 


### PR DESCRIPTION
cc: @jfly 

We have a mechanism to determine if we should run our list of checks
on the files being committed. Generally these checks are pretty
simplistic. For example, does the file exist, or is it a directory?

Also, in order to avoid running checks on large binary files we run
a heuristic against every file currently being committed.
Unfortunately, this binary check is prone to errors and is now causing
performance issues.

In order to avoid this binary file test, we do some quick filtering
based on file extension. If the file is an image, we definitely do not
want to run checks on it. If the file is a Ruby source code file, we
definitely do want to run checks on it.

This will allow us to avoid running the binary test in most cases.

Fixes #255 