### PR TITLE
Ignore standard error when checking grep version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ cache:
  - npm
 language: ruby
 rvm:
-  - jruby-9.0.5.0
+  - jruby
   - 2.0.0
   - 2.1.9
   - 2.2.5

--- a/lib/pre-commit/checks/grep.rb
+++ b/lib/pre-commit/checks/grep.rb
@@ -1,3 +1,5 @@
+require 'open3'
+
 require 'pre-commit/checks/shell'
 require 'pre-commit/error_list'
 require 'pre-commit/line'
@@ -91,7 +93,11 @@ module PreCommit
       end
 
       def detect_grep_version
-        `grep --version | head -n 1 | sed -e 's/^[^0-9.]*\([0-9.]*\)$/\1/'`
+        first_line = Open3.popen2('grep', '--version') do |_, stdout, _|
+          stdout.readline
+        end
+
+        first_line.sub(/^[^0-9.]*\([0-9.]*\)$/, '\1')
       end
 
       def extra_execute(files)


### PR DESCRIPTION
We are currently shelling out to the `grep` command for some
functionality of the pre-commit gem. In order to do this we need to
reason about the `grep` executable running on the system.

To introspect the command we check the output of the `grep --version`
command and decide what to do next. On Alpine Linux grep does not
report its version and instead outputs an error message. Here we
ignore the standard error stream when checking grep's version.

fixes #265 
@fgrehm