### PR TITLE
Security: Depend on RuboCop ~> 0.49

### DIFF
--- a/pre-commit.gemspec
+++ b/pre-commit.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('minitest', '~> 4.0')
   s.add_development_dependency('minitest-reporters', '~> 0')
   s.add_development_dependency('rake', '~> 10.0')
-  s.add_development_dependency('rubocop', '~> 0.25')
+  s.add_development_dependency('rubocop', '~> 0.49')
 
   if s.respond_to? :specification_version then
     s.specification_version = 3


### PR DESCRIPTION
RuboCop 0.48.1 and earlier does not use /tmp in safe way, allowing
local users to exploit this to tamper with cache files belonging to
other users.

_cf._ https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-8418