### PR TITLE
Fix grep version detection on busybox / alpine

### DIFF
--- a/lib/pre-commit/checks/grep.rb
+++ b/lib/pre-commit/checks/grep.rb
@@ -93,11 +93,12 @@ module PreCommit
       end
 
       def detect_grep_version
-        first_line = Open3.popen2('grep', '--version') do |_, stdout, _|
-          stdout.readline
-        end
+        Open3.popen3('grep', '--version') do |_, stdout, _|
+          return '' if stdout.eof?
 
-        first_line.sub(/^[^0-9.]*\([0-9.]*\)$/, '\1')
+          first_line = stdout.readline
+          return first_line.sub(/^[^0-9.]*\([0-9.]*\)$/, '\1')
+        end
       end
 
       def extra_execute(files)


### PR DESCRIPTION
@jish this is a follow up of GH-265 and GH-266, I was getting these errors on latest release:

```
$ git ci
grep: unrecognized option: version
BusyBox v1.26.2 (2017-11-23 08:40:54 GMT) multi-call binary.

Usage: grep [-HhnlLoqvsriwFE] [-m N] [-A/B/C N] PATTERN/-e PATTERN.../-f FILE [FILE]...

Search for PATTERN in FILEs (or stdin)

        -H      Add 'filename:' prefix
        -h      Do not add 'filename:' prefix
        -n      Add 'line_no:' prefix
        -l      Show only names of files that match
        -L      Show only names of files that don't match
        -c      Show only count of matching lines
        -o      Show only the matching part of line
        -q      Quiet. Return 0 if PATTERN is found, 1 otherwise
        -v      Select non-matching lines
        -s      Suppress open and read errors
        -r      Recurse
        -i      Ignore case
        -w      Match whole words only
        -x      Match whole lines only
        -F      PATTERN is a literal (not regexp)
        -E      PATTERN is an extended regexp
        -m N    Match up to N times per file
        -A N    Print N lines of trailing context
        -B N    Print N lines of leading context
        -C N    Same as '-A N -B N'
        -e PTRN Pattern to match
        -f FILE Read pattern from file
/usr/local/bundle/gems/pre-commit-0.38.0/lib/pre-commit/checks/grep.rb:98:in `readline': end of file reached (EOFError)
        from /usr/local/bundle/gems/pre-commit-0.38.0/lib/pre-commit/checks/grep.rb:98:in `block in detect_grep_version'
        from /usr/local/lib/ruby/2.4.0/open3.rb:205:in `popen_run'
        from /usr/local/lib/ruby/2.4.0/open3.rb:147:in `popen2'
        from /usr/local/bundle/gems/pre-commit-0.38.0/lib/pre-commit/checks/grep.rb:96:in `detect_grep_version'
        from /usr/local/bundle/gems/pre-commit-0.38.0/lib/pre-commit/checks/grep.rb:87:in `grep'
        from /usr/local/bundle/gems/pre-commit-0.38.0/lib/pre-commit/checks/grep.rb:54:in `block in call'
```