### PR TITLE
Add execjs to dependencies

### DIFF
--- a/lib/pre-commit/checks/js.rb
+++ b/lib/pre-commit/checks/js.rb
@@ -5,9 +5,7 @@ module PreCommit
     class Js < Plugin
       def call(staged_files)
         require 'execjs'
-      rescue RuntimeError, LoadError => e
-        $stderr.puts "Could not load execjs: #{e}"
-      else
+
         staged_files = files_filter(staged_files)
         return if staged_files.empty?
 

--- a/pre-commit.gemspec
+++ b/pre-commit.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
   s.description = "A git pre-commit hook written in ruby with a few more tricks up its sleeve"
 
   s.add_dependency('pluginator', '~> 1.5')
+  s.add_dependency('execjs')
 
   s.add_development_dependency('benchmark-ips')
   s.add_development_dependency('minitest', '~> 4.0')


### PR DESCRIPTION
This PR relates to https://github.com/jish/pre-commit/issues/234

When I run pre-commit, it warns me `Could not load execjs: cannot load such file -- execjs`. I found In js plugin, pre-commit checks if it can load execjs or not. I think it is kind of inconvenient I need to manually install execjs in order to use js plugin, so added it to dependency! 👍 