### PR TITLE
Add ruby 2.5.1 to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,5 +20,6 @@ rvm:
   - 2.1.9
   - 2.2.5
   - 2.3.1
+  - 2.5.1
 matrix:
   fast_finish: true

--- a/templates/gem/.travis.yml
+++ b/templates/gem/.travis.yml
@@ -9,6 +9,7 @@ rvm:
   - ruby-2.1
   - ruby-2.2
   - ruby-2.3.0
+  - ruby-2.5.1
 matrix:
   fast_finish: true
   allow_failures:


### PR DESCRIPTION
I saw the ruby version in travis is a little bit old, so I added ruby 2.5.1! 👍 