### PR TITLE
Upgrade minitest and minitest-reporters

### DIFF
--- a/pre-commit.gemspec
+++ b/pre-commit.gemspec
@@ -22,8 +22,8 @@ Gem::Specification.new do |s|
   s.add_dependency('pluginator', '~> 1.5')
 
   s.add_development_dependency('benchmark-ips')
-  s.add_development_dependency('minitest', '~> 4.0')
-  s.add_development_dependency('minitest-reporters', '~> 0')
+  s.add_development_dependency('minitest', '~> 5.0')
+  s.add_development_dependency('minitest-reporters', '~> 1.0')
   s.add_development_dependency('rake', '~> 10.0')
   s.add_development_dependency('rubocop', '~> 0.49')
 

--- a/templates/gem/test/plugins/pre_commit/checks/PLUGIN_NAME_test.rb
+++ b/templates/gem/test/plugins/pre_commit/checks/PLUGIN_NAME_test.rb
@@ -11,13 +11,13 @@ describe PreCommit::Checks::<%= name.capitalize %> do
   let(:check){ PreCommit::Checks::<%= name.capitalize %>.new(nil, nil, []) }
 
   it "does nothing" do
-    check.send(:run_check, "rake").must_equal(nil)
+    check.send(:run_check, "rake").must_be_nil
   end
 
   it "checks files" do
     Dir.chdir(test_files) do
       # TODO: create example files in test/files
-      check.send(:run_check, ".keep").must_equal(nil)
+      check.send(:run_check, ".keep").must_be_nil
     end
   end
 

--- a/test/unit/plugins/pluginator/extensions/find_check_test.rb
+++ b/test/unit/plugins/pluginator/extensions/find_check_test.rb
@@ -23,7 +23,7 @@ describe Pluginator::Extensions::FindCheck do
   end
 
   it "does not find missing plugin" do
-    @tester.find_check("missing_plugin").must_equal( nil )
+    @tester.find_check("missing_plugin").must_be_nil
     $stderr.string.must_equal(<<-EXPECTED)
 Could not find plugin supporting missing_plugin / MissingPlugin,
 available plugins: BeforeAll

--- a/test/unit/plugins/pre_commit/checks/before_all_test.rb
+++ b/test/unit/plugins/pre_commit/checks/before_all_test.rb
@@ -5,7 +5,7 @@ describe PreCommit::Checks::BeforeAll do
   subject { PreCommit::Checks::BeforeAll.new(nil, nil, []) }
 
   it "succeeds if nothing changed" do
-    subject.call([]).must_equal nil
+    subject.call([]).must_be_nil
   end
 
   it "filters out rb files" do
@@ -17,7 +17,7 @@ describe PreCommit::Checks::BeforeAll do
   end
 
   it "succeeds if only good changes" do
-    subject.call([fixture_file('valid_spec.rb')]).must_equal nil
+    subject.call([fixture_file('valid_spec.rb')]).must_be_nil
   end
 
   it "fails if file contains before(:all)" do

--- a/test/unit/plugins/pre_commit/checks/ci_test.rb
+++ b/test/unit/plugins/pre_commit/checks/ci_test.rb
@@ -6,7 +6,7 @@ describe PreCommit::Checks::Ci do
 
   it "succeeds if rake succeeds" do
     check.stub :system, true do
-      check.call([]).must_equal nil
+      check.call([]).must_be_nil
     end
   end
 

--- a/test/unit/plugins/pre_commit/checks/coffeelint_test.rb
+++ b/test/unit/plugins/pre_commit/checks/coffeelint_test.rb
@@ -11,11 +11,11 @@ describe PreCommit::Checks::Coffeelint do
   let(:check) {PreCommit::Checks::Coffeelint.new(nil, config, [])}
 
   it "succeds if nothing changed" do
-    check.call([]).must_equal nil
+    check.call([]).must_be_nil
   end
 
   it "succeeds for good code" do
-    check.call([fixture_file('good.coffee')]).must_equal nil
+    check.call([fixture_file('good.coffee')]).must_be_nil
   end
 
   it "fails for bad formatted code" do

--- a/test/unit/plugins/pre_commit/checks/console_log_test.rb
+++ b/test/unit/plugins/pre_commit/checks/console_log_test.rb
@@ -15,15 +15,15 @@ describe PreCommit::Checks::ConsoleLog do
   end
 
   it "succeeds if nothing changed" do
-    subject.call([]).must_equal nil
+    subject.call([]).must_be_nil
   end
 
   it "succeeds with valid .js file changed" do
-    subject.call([fixture_file('valid_file.js')]).must_equal nil
+    subject.call([fixture_file('valid_file.js')]).must_be_nil
   end
 
   it "succeeds if non js files has console.log" do
-    subject.call([fixture_file('changelog.md')]).must_equal nil
+    subject.call([fixture_file('changelog.md')]).must_be_nil
   end
 
   it "fails if a js file has a console.log" do

--- a/test/unit/plugins/pre_commit/checks/csslint_test.rb
+++ b/test/unit/plugins/pre_commit/checks/csslint_test.rb
@@ -6,7 +6,7 @@ describe PreCommit::Checks::Csslint do
   let(:check){ PreCommit::Checks::Csslint.new(nil, nil, []) }
 
   it "succeeds if nothing changed" do
-    check.call([]).must_equal nil
+    check.call([]).must_be_nil
   end
 
   it "succeeds if only good changes" do
@@ -14,7 +14,7 @@ describe PreCommit::Checks::Csslint do
   end
 
   it "succeeds if only good changes" do
-    check.call([fixture_file('valid_file.css')]).must_equal nil
+    check.call([fixture_file('valid_file.css')]).must_be_nil
   end
 
   it "fails if file contains errors" do

--- a/test/unit/plugins/pre_commit/checks/debugger_test.rb
+++ b/test/unit/plugins/pre_commit/checks/debugger_test.rb
@@ -5,7 +5,7 @@ describe PreCommit::Checks::Debugger do
   subject{ PreCommit::Checks::Debugger.new(nil, nil, []) }
 
   it "succeeds if nothing changed" do
-    subject.call([]).must_equal nil
+    subject.call([]).must_be_nil
   end
 
   it "filters out Gemfiles files" do
@@ -19,7 +19,7 @@ describe PreCommit::Checks::Debugger do
   end
 
   it "succeeds if only good changes" do
-    subject.call([fixture_file('valid_file.rb')]).must_equal nil
+    subject.call([fixture_file('valid_file.rb')]).must_be_nil
   end
 
   it "fails if file contains debugger" do
@@ -40,11 +40,11 @@ describe PreCommit::Checks::Debugger do
 
   it "Skips checking the Gemfile" do
     files = [fixture_file("with_debugger/Gemfile")]
-    subject.call(files).must_equal nil
+    subject.call(files).must_be_nil
   end
 
   it "Skips checking the Gemfile.lock" do
     files = [fixture_file("with_debugger/Gemfile.lock")]
-    subject.call(files).must_equal nil
+    subject.call(files).must_be_nil
   end
 end

--- a/test/unit/plugins/pre_commit/checks/gemfile_path_test.rb
+++ b/test/unit/plugins/pre_commit/checks/gemfile_path_test.rb
@@ -11,28 +11,28 @@ describe PreCommit::Checks::GemfilePath do
   after(&:destroy_temp_dir)
 
   it "succeeds if nothing changed" do
-    check.call([]).must_equal nil
+    check.call([]).must_be_nil
   end
 
   it "succeeds if non-gemfile changes" do
     write "Foofile", <<-RUBY
       gem "foo", :path => "xxx"
     RUBY
-    check.call(["Foofile"]).must_equal nil
+    check.call(["Foofile"]).must_be_nil
   end
 
   it "succeeds if only good changes" do
     write "Gemfile", <<-RUBY
       gem "foo"
     RUBY
-    check.call(["Gemfile"]).must_equal nil
+    check.call(["Gemfile"]).must_be_nil
   end
 
   it "succeeds with innocent path check" do
     write "Gemfile", <<-RUBY
       gem "foo_path"
     RUBY
-    check.call(["Gemfile"]).must_equal nil
+    check.call(["Gemfile"]).must_be_nil
   end
 
   it "fails if Gemfile contains path =>" do
@@ -59,7 +59,7 @@ describe PreCommit::Checks::GemfilePath do
     write "Gemfile", <<-RUBY
       # gem 'my-internal-app-gem', '~> 0.0.1', :path => './lib/my-internal-app-gem'
     RUBY
-    check.call(["Gemfile"]).must_equal nil, "There should be no errors"
+    check.call(["Gemfile"]).must_be_nil
   end
 
 end

--- a/test/unit/plugins/pre_commit/checks/go_build_test.rb
+++ b/test/unit/plugins/pre_commit/checks/go_build_test.rb
@@ -5,7 +5,7 @@ describe PreCommit::Checks::GoBuild do
   let(:check) {PreCommit::Checks::GoBuild.new(nil, nil, [])}
 
   it "succeds if nothing changed" do
-    check.call([]).must_equal nil
+    check.call([]).must_be_nil
   end
 
   it "succeeds for good code" do

--- a/test/unit/plugins/pre_commit/checks/go_fmt_test.rb
+++ b/test/unit/plugins/pre_commit/checks/go_fmt_test.rb
@@ -5,7 +5,7 @@ describe PreCommit::Checks::GoFmt do
   let(:check) {PreCommit::Checks::GoFmt.new(nil, nil, [])}
 
   it "succeds if nothing changed" do
-    check.call([]).must_equal nil
+    check.call([]).must_be_nil
   end
 
   it "succeeds for good code" do

--- a/test/unit/plugins/pre_commit/checks/jshint_test.rb
+++ b/test/unit/plugins/pre_commit/checks/jshint_test.rb
@@ -12,7 +12,7 @@ describe PreCommit::Checks::Jshint do
   let(:check){ PreCommit::Checks::Jshint.new(nil, config, []) }
 
   it "succeeds if nothing changed" do
-    check.call([]).must_equal nil
+    check.call([]).must_be_nil
   end
 
   it "succeeds if only good changes" do
@@ -20,7 +20,7 @@ describe PreCommit::Checks::Jshint do
   end
 
   it "succeeds if only good changes" do
-    check.call([fixture_file('valid_file.js')]).must_equal nil
+    check.call([fixture_file('valid_file.js')]).must_be_nil
   end
 
   it "fails if file contains debugger" do

--- a/test/unit/plugins/pre_commit/checks/jslint_test.rb
+++ b/test/unit/plugins/pre_commit/checks/jslint_test.rb
@@ -5,11 +5,11 @@ describe PreCommit::Checks::Jslint do
   let(:check){ PreCommit::Checks::Jslint.new(nil, nil, []) }
 
   it "succeeds if nothing changed" do
-    check.call([]).must_equal nil
+    check.call([]).must_be_nil
   end
 
   it "succeeds if only good changes" do
-    check.call([fixture_file('valid_file.js')]).must_equal nil
+    check.call([fixture_file('valid_file.js')]).must_be_nil
   end
 
   it "fails if file contains debugger" do

--- a/test/unit/plugins/pre_commit/checks/json_test.rb
+++ b/test/unit/plugins/pre_commit/checks/json_test.rb
@@ -5,11 +5,11 @@ describe PreCommit::Checks::Json do
   let(:check) {PreCommit::Checks::Json.new(nil, nil, [])}
 
   it "succeds if nothing changed" do
-    check.call([]).must_equal nil
+    check.call([]).must_be_nil
   end
 
   it "succeeds for good code" do
-    check.call([fixture_file('good.json')]).must_equal nil
+    check.call([fixture_file('good.json')]).must_be_nil
   end
 
   it "fails for bad formatted code" do

--- a/test/unit/plugins/pre_commit/checks/local_test.rb
+++ b/test/unit/plugins/pre_commit/checks/local_test.rb
@@ -7,12 +7,12 @@ describe PreCommit::Checks::Local do
   let(:check) { PreCommit::Checks::Local.new(nil, nil, []) }
 
   it "succeeds if there is no config" do
-    check.call([]).must_equal nil
+    check.call([]).must_be_nil
   end
 
   it "succeeds if script succeeds" do
     check.script = config_file
-    check.call([]).must_equal nil
+    check.call([]).must_be_nil
   end
 
   it "fails if script fails" do

--- a/test/unit/plugins/pre_commit/checks/merge_conflict_test.rb
+++ b/test/unit/plugins/pre_commit/checks/merge_conflict_test.rb
@@ -5,11 +5,11 @@ describe PreCommit::Checks::MergeConflict do
   let(:check){ PreCommit::Checks::MergeConflict.new(nil, nil, []) }
 
   it "succeeds if nothing changed" do
-    check.call([]).must_equal nil
+    check.call([]).must_be_nil
   end
 
   it "succeeds if only good changes" do
-    check.call([fixture_file('valid_file.rb')]).must_equal nil
+    check.call([fixture_file('valid_file.rb')]).must_be_nil
   end
 
   it "fails if file contains merge conflict" do

--- a/test/unit/plugins/pre_commit/checks/migration_test.rb
+++ b/test/unit/plugins/pre_commit/checks/migration_test.rb
@@ -17,14 +17,14 @@ describe PreCommit::Checks::Migration do
   end
 
   it "succeeds if there is no change" do
-    check.call([]).must_equal nil
+    check.call([]).must_be_nil
   end
 
   it "succeeds if there is a migration and a schema change" do
     in_new_directory do
       write "db/migrate/20140718171920_foo.rb", "Yep"
       write "db/schema.rb", "version 20140718171920 bla"
-      check.call(['db/migrate/20140718171920_foo.rb', 'db/schema.rb']).must_equal nil
+      check.call(['db/migrate/20140718171920_foo.rb', 'db/schema.rb']).must_be_nil
     end
   end
 
@@ -32,7 +32,7 @@ describe PreCommit::Checks::Migration do
     in_new_directory do
       write "db/migrate/20140718171920_foo.rb", "Yep"
       write "db/foo_structure.sql", "version 20140718171920 bla"
-      check.call(['db/migrate/20140718171920_foo.rb', 'db/foo_structure.sql']).must_equal nil
+      check.call(['db/migrate/20140718171920_foo.rb', 'db/foo_structure.sql']).must_be_nil
     end
   end
 
@@ -44,18 +44,18 @@ describe PreCommit::Checks::Migration do
 
         INSERT INTO schema_migrations (version) VALUES ('20140718171920');
       STRUCTURE
-      check.call(['db/migrate/20140718171920_foo.rb', 'db/foo_structure.sql']).must_equal nil
+      check.call(['db/migrate/20140718171920_foo.rb', 'db/foo_structure.sql']).must_be_nil
     end
   end
 
   it "succeeds if random files are changed" do
-    check.call(['public/javascript/foo.js', 'lib/bar.rb']).must_equal nil
+    check.call(['public/javascript/foo.js', 'lib/bar.rb']).must_be_nil
   end
 
   it "succeeds when initial schema is added with version 0" do
     in_new_directory do
       write "db/schema.rb", "brand new 0 version"
-      check.call(['db/schema.rb']).must_equal nil
+      check.call(['db/schema.rb']).must_be_nil
     end
   end
 

--- a/test/unit/plugins/pre_commit/checks/nb_space_test.rb
+++ b/test/unit/plugins/pre_commit/checks/nb_space_test.rb
@@ -5,11 +5,11 @@ describe PreCommit::Checks::NbSpace do
   let(:check){ PreCommit::Checks::NbSpace.new(nil, nil, []) }
 
   it "succeeds if nothing changed" do
-    check.call([]).must_equal nil
+    check.call([]).must_be_nil
   end
 
   it "succeeds if only good changes" do
-    check.call([fixture_file("pre-commit.rb")]).must_equal nil
+    check.call([fixture_file("pre-commit.rb")]).must_be_nil
   end
 
   it "fails if script fails" do

--- a/test/unit/plugins/pre_commit/checks/pry_test.rb
+++ b/test/unit/plugins/pre_commit/checks/pry_test.rb
@@ -5,11 +5,11 @@ describe PreCommit::Checks::Pry do
   let(:check){ PreCommit::Checks::Pry.new(nil, nil, []) }
 
   it "succeeds if nothing changed" do
-    check.call([]).must_equal nil
+    check.call([]).must_be_nil
   end
 
   it "succeeds if only good changes" do
-    check.call([fixture_file('valid_file.rb')]).must_equal nil
+    check.call([fixture_file('valid_file.rb')]).must_be_nil
   end
 
   it "fails if file contains pry" do

--- a/test/unit/plugins/pre_commit/checks/rspec_focus_test.rb
+++ b/test/unit/plugins/pre_commit/checks/rspec_focus_test.rb
@@ -5,19 +5,19 @@ describe PreCommit::Checks::RspecFocus do
   let(:check){ PreCommit::Checks::RspecFocus.new(nil, nil, []) }
 
   it "succeeds if nothing changed" do
-    check.call([]).must_equal nil
+    check.call([]).must_be_nil
   end
 
   it "succeeds on non-specs" do
-    check.call([fixture_file('bad-spec.rb')]).must_equal nil
+    check.call([fixture_file('bad-spec.rb')]).must_be_nil
   end
 
   it "succeeds if only good changes" do
-    check.call([fixture_file('rspec_focus_good_spec.rb')]).must_equal nil
+    check.call([fixture_file('rspec_focus_good_spec.rb')]).must_be_nil
   end
 
   it "succeeds when there are keywords in the description" do
-    check.call([fixture_file('rspec_focus_sugar_good_spec.rb')]).must_equal nil
+    check.call([fixture_file('rspec_focus_sugar_good_spec.rb')]).must_be_nil
   end
 
   it 'fails if focus specified on describe, context or example block using any valid syntax' do

--- a/test/unit/plugins/pre_commit/checks/rubocop_test.rb
+++ b/test/unit/plugins/pre_commit/checks/rubocop_test.rb
@@ -14,11 +14,11 @@ describe PreCommit::Checks::Rubocop do
   let(:check){ PreCommit::Checks::Rubocop.new(nil, config, []) }
 
   it "succeeds if nothing changed" do
-    check.call([]).must_equal nil
+    check.call([]).must_be_nil
   end
 
   it "succeeds if only good changes" do
-    check.call([fixture_file('valid_file.rb')]).must_equal nil
+    check.call([fixture_file('valid_file.rb')]).must_be_nil
   end
 
   it "fails if file contains errors" do
@@ -66,7 +66,7 @@ describe PreCommit::Checks::Rubocop do
     let(:flags) { '--fail-level=fatal' }
 
     it "succeeds if file contains errors" do
-      check.call([fixture_file('pry_file.rb')]).must_equal nil
+      check.call([fixture_file('pry_file.rb')]).must_be_nil
     end
   end
 end

--- a/test/unit/plugins/pre_commit/checks/ruby_symbol_hashrockets_test.rb
+++ b/test/unit/plugins/pre_commit/checks/ruby_symbol_hashrockets_test.rb
@@ -5,11 +5,11 @@ describe PreCommit::Checks::RubySymbolHashrockets do
   let(:check){ PreCommit::Checks::RubySymbolHashrockets.new(nil, nil, []) }
 
   it "succeeds if nothing changed" do
-    check.call([]).must_equal nil
+    check.call([]).must_be_nil
   end
 
   it "succeeds with valid" do
-    check.call([fixture_file('valid_hashrockets.rb')]).must_equal nil
+    check.call([fixture_file('valid_hashrockets.rb')]).must_be_nil
   end
 
   it "fails with invalid" do

--- a/test/unit/plugins/pre_commit/checks/scss_lint_test.rb
+++ b/test/unit/plugins/pre_commit/checks/scss_lint_test.rb
@@ -10,11 +10,11 @@ describe PreCommit::Checks::ScssLint do
   let(:check) {PreCommit::Checks::ScssLint.new(nil, config, [])}
 
   it "succeds if nothing changed" do
-    check.call([]).must_equal nil
+    check.call([]).must_be_nil
   end
 
   it "succeeds for good code" do
-    check.call([fixture_file('good.scss')]).must_equal nil
+    check.call([fixture_file('good.scss')]).must_be_nil
   end
 
   it "fails for bad formatted code" do

--- a/test/unit/plugins/pre_commit/checks/tabs_test.rb
+++ b/test/unit/plugins/pre_commit/checks/tabs_test.rb
@@ -5,7 +5,7 @@ describe PreCommit::Checks::Tabs do
   let(:check) { PreCommit::Checks::Tabs.new(nil, nil, []) }
 
   it "passes without files" do
-    check.call([]).must_equal nil
+    check.call([]).must_be_nil
   end
 
   it "detect a tab" do
@@ -17,11 +17,11 @@ describe PreCommit::Checks::Tabs do
   end
 
   it "passes with a valid file" do
-    check.call([fixture_file('valid_file.rb')]).must_equal nil
+    check.call([fixture_file('valid_file.rb')]).must_be_nil
   end
 
   it "passes with a binary file with initial tab" do
-    check.call([fixture_file('property_sets-0.3.0.gem')]).must_equal nil
+    check.call([fixture_file('property_sets-0.3.0.gem')]).must_be_nil
   end
 
   it "shows error message when an initial tab is found" do

--- a/test/unit/plugins/pre_commit/checks/whitespace_test.rb
+++ b/test/unit/plugins/pre_commit/checks/whitespace_test.rb
@@ -12,12 +12,12 @@ describe PreCommit::Checks::Whitespace do
   let(:check){ PreCommit::Checks::Whitespace.new(nil, nil, []) }
 
   it "succeeds if nothing changed" do
-    check.call(['a']).must_equal nil
+    check.call(['a']).must_be_nil
   end
 
   it "succeeds if only good changes" do
     `echo aaa > b && git add b`
-    check.call(['a', 'b']).must_equal nil
+    check.call(['a', 'b']).must_be_nil
   end
 
   describe 'staged bad changes' do
@@ -28,12 +28,12 @@ describe PreCommit::Checks::Whitespace do
 
     it "succeeds if the target files don't have bad changes" do
       `echo '   ' > b && git add b`
-      check.call(['a']).must_equal nil
+      check.call(['a']).must_be_nil
     end
 
     it "succeeds if no target files" do
       `echo '   ' > b && git add b`
-      check.call([]).must_equal nil
+      check.call([]).must_be_nil
     end
   end
 end

--- a/test/unit/plugins/pre_commit/checks/yaml_test.rb
+++ b/test/unit/plugins/pre_commit/checks/yaml_test.rb
@@ -5,11 +5,11 @@ describe PreCommit::Checks::Yaml do
   let(:check) {PreCommit::Checks::Yaml.new(nil, nil, [])}
 
   it "succeds if nothing changed" do
-    check.call([]).must_equal nil
+    check.call([]).must_be_nil
   end
 
   it "succeeds for good code" do
-    check.call([fixture_file('good.yml')]).must_equal nil
+    check.call([fixture_file('good.yml')]).must_be_nil
   end
 
   it "skips files with serialized ruby" do

--- a/test/unit/plugins/pre_commit/configuration/providers/default_test.rb
+++ b/test/unit/plugins/pre_commit/configuration/providers/default_test.rb
@@ -25,7 +25,7 @@ describe PreCommit::Configuration::Providers::Default do
     example = subject.new({:test1 => 1, :test2 => 2})
     example[:test1].must_equal(1)
     example[:test2].must_equal(2)
-    example[:test3].must_equal(nil)
+    example[:test3].must_be_nil
   end
 
   it "does not allow update" do

--- a/test/unit/plugins/pre_commit/configuration/providers/git_old_test.rb
+++ b/test/unit/plugins/pre_commit/configuration/providers/git_old_test.rb
@@ -21,7 +21,7 @@ describe PreCommit::Configuration::Providers::GitOld do
 
     it "reads values" do
       example = subject.new
-      example[:test1].must_equal(nil)
+      example[:test1].must_be_nil
       example[:checks].must_equal([:jshint, :local])
       example[:other].must_equal("jshint,local")
     end

--- a/test/unit/plugins/pre_commit/configuration/providers/git_test.rb
+++ b/test/unit/plugins/pre_commit/configuration/providers/git_test.rb
@@ -21,7 +21,7 @@ describe PreCommit::Configuration::Providers::Git do
 
     it "reads values" do
       example = subject.new
-      example[:test1].must_equal(nil)
+      example[:test1].must_be_nil
       example[:test2].must_equal("2")
       example[:test3].must_equal("3")
     end

--- a/test/unit/plugins/pre_commit/configuration/providers/yaml_test.rb
+++ b/test/unit/plugins/pre_commit/configuration/providers/yaml_test.rb
@@ -27,7 +27,7 @@ describe PreCommit::Configuration::Providers::Yaml do
       example[:test1].must_equal(1)
       example[:test2].must_equal(2)
       example[:test3].must_equal(3)
-      example[:test4].must_equal(nil)
+      example[:test4].must_be_nil
     end
 
     it "reads system and global values" do
@@ -38,7 +38,7 @@ describe PreCommit::Configuration::Providers::Yaml do
       example[:test1].must_equal(4)
       example[:test2].must_equal(5)
       example[:test3].must_equal(3)
-      example[:test4].must_equal(nil)
+      example[:test4].must_be_nil
     end
 
     it "reads system and local values" do
@@ -50,7 +50,7 @@ describe PreCommit::Configuration::Providers::Yaml do
       example[:test1].must_equal(6)
       example[:test2].must_equal(2)
       example[:test3].must_equal(3)
-      example[:test4].must_equal(nil)
+      example[:test4].must_be_nil
     end
 
     it "reads system and local values" do
@@ -63,7 +63,7 @@ describe PreCommit::Configuration::Providers::Yaml do
       example[:test1].must_equal(6)
       example[:test2].must_equal(5)
       example[:test3].must_equal(3)
-      example[:test4].must_equal(nil)
+      example[:test4].must_be_nil
     end
 
     it "saves values" do

--- a/test/unit/pre-commit/checks/grep_test.rb
+++ b/test/unit/pre-commit/checks/grep_test.rb
@@ -7,7 +7,7 @@ describe PreCommit::Checks::Grep do
   end
 
   it "succeeds if nothing changed" do
-    subject.call([]).must_equal nil
+    subject.call([]).must_be_nil
   end
 
   it "succeeds if nothing changed" do
@@ -16,7 +16,7 @@ describe PreCommit::Checks::Grep do
 
   it "succeeds if file has no pattern" do
     subject.instance_variable_set(:@pattern, "other")
-    subject.call([fixture_file('file_with_nb_space.rb')]).must_equal nil
+    subject.call([fixture_file('file_with_nb_space.rb')]).must_be_nil
   end
 
   it "fails if file has pattern" do
@@ -44,7 +44,7 @@ test/files/file_with_nb_space.rb:1:test")
   it "respects extra_grep" do
     subject.instance_variable_set(:@pattern, "test")
     subject.instance_variable_set(:@extra_grep, %w{-v test})
-    subject.call([fixture_file('file_with_nb_space.rb')]).must_equal(nil)
+    subject.call([fixture_file('file_with_nb_space.rb')]).must_be_nil
   end
 
   it "finds grep for FreeBSD" do

--- a/test/unit/pre-commit/checks/js_test.rb
+++ b/test/unit/pre-commit/checks/js_test.rb
@@ -5,10 +5,10 @@ describe PreCommit::Checks::Js do
   let(:check){ PreCommit::Checks::Js.new(nil, nil, []) }
 
   it "succeeds if nothing changed" do
-    check.call([]).must_equal nil
+    check.call([]).must_be_nil
   end
 
   it "succeeds if non-js changed" do
-    check.call(["bar.foo"]).must_equal nil
+    check.call(["bar.foo"]).must_be_nil
   end
 end

--- a/test/unit/pre-commit/checks/plugin/config_file_test.rb
+++ b/test/unit/pre-commit/checks/plugin/config_file_test.rb
@@ -58,7 +58,7 @@ USAGE
       let(:alternate_location){ 'missing.config' }
 
       it 'returns nil' do
-        subject.location.must_equal(nil)
+        subject.location.must_be_nil
       end
     end
   end
@@ -68,7 +68,7 @@ USAGE
     let(:alternate_location){ nil }
 
     it 'returns nil' do
-      subject.location.must_equal(nil)
+      subject.location.must_be_nil
     end
   end
 end

--- a/test/unit/pre-commit/checks/shell_test.rb
+++ b/test/unit/pre-commit/checks/shell_test.rb
@@ -7,7 +7,7 @@ describe PreCommit::Checks::Shell do
   end
 
   it "nil for success" do
-    subject.send(:execute_raw, "true").must_equal nil
+    subject.send(:execute_raw, "true").must_be_nil
   end
 
   it "error for fail" do
@@ -19,7 +19,7 @@ describe PreCommit::Checks::Shell do
   end
 
   it "nil for fail on expected false" do
-    subject.send(:execute_raw, "false", success_status: false).must_equal nil
+    subject.send(:execute_raw, "false", success_status: false).must_be_nil
   end
 
   it "builds_command" do

--- a/test/unit/pre-commit/configuration/providers_test.rb
+++ b/test/unit/pre-commit/configuration/providers_test.rb
@@ -44,7 +44,7 @@ DATA
       provider[:test1].must_equal([:c])
       provider[:test2].must_equal("5")
       provider[:test3].must_equal(3)
-      provider[:test4].must_equal(nil)
+      provider[:test4].must_be_nil
     end
 
     it "updates git configurations" do

--- a/test/unit/pre-commit/plugins_list_test.rb
+++ b/test/unit/pre-commit/plugins_list_test.rb
@@ -41,7 +41,7 @@ describe PreCommit::PluginsList do
     end
 
     it "does not find class" do
-      subject.send(:find_class, :class2).must_equal(nil)
+      subject.send(:find_class, :class2).must_be_nil
     end
 
   end

--- a/test/unit/pre-commit/utils/git_conversions_test.rb
+++ b/test/unit/pre-commit/utils/git_conversions_test.rb
@@ -36,7 +36,7 @@ describe PreCommit::Utils::GitConversions do
     end
 
     it "transforms empty string to nil" do
-      subject.git_to_ruby("").must_equal(nil)
+      subject.git_to_ruby("").must_be_nil
     end
 
     it "transforms string to symbols" do


### PR DESCRIPTION
The `jruby` builds were failing to find a module inside of the `minitest-reporters` gem. It was using an old, outdated version of `minitest-reporters` due to our version specification of `~> 0`.

Upgraded `minitest-reporters` to `~> 1`.

That required an update of `minitest` to `~> 5`. The minitest 5 upgrade brought on some deprecation warnings that we needed to clean up. We can no longer use `must_equal` with `nil` as an argument, it must be changed to `must_be_nil`.

cc: @shuheiktgw