### PR TITLE
Drop Ruby 2.0 from Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,10 @@ cache:
 language: ruby
 rvm:
   - jruby
-  - 2.1.9
-  - 2.2.5
-  - 2.3.1
-  - 2.5.1
+  - 2.1
+  - 2.2
+  - 2.3
+  - 2.4
+  - 2.5
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,10 @@ cache:
 language: ruby
 rvm:
   - jruby
-  - 2.1
-  - 2.2
-  - 2.3
-  - 2.4
-  - 2.5
+  - 2.1.10
+  - 2.2.10
+  - 2.3.7
+  - 2.4.4
+  - 2.5.1
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ cache:
 language: ruby
 rvm:
   - jruby
-  - 2.0.0
   - 2.1.9
   - 2.2.5
   - 2.3.1


### PR DESCRIPTION
RuboCop will no longer install on Ruby 2.0, and Ruby is on the 2.5.x
branch now.

cc: @shuheiktgw