### PR TITLE
Make execjs warning clearer

### DIFF
--- a/lib/pre-commit/checks/js.rb
+++ b/lib/pre-commit/checks/js.rb
@@ -6,7 +6,7 @@ module PreCommit
       def call(staged_files)
         require 'execjs'
       rescue RuntimeError, LoadError => e
-        $stderr.puts "Could not load execjs: #{e}"
+        $stderr.puts "Could not load execjs: #{e}. You need to manually install execjs to use JavaScript plugins for security reasons."
       else
         staged_files = files_filter(staged_files)
         return if staged_files.empty?


### PR DESCRIPTION
This PR relates to https://github.com/jish/pre-commit/pull/269 👍 
Since the intention of the original warning message is not clear enough, I changed the message to tell developers what to do in order to use JavaScript plugins!