### PR TITLE
simple bug fix

### DIFF
--- a/lib/plugins/pre_commit/checks/migration.rb
+++ b/lib/plugins/pre_commit/checks/migration.rb
@@ -26,7 +26,7 @@ module PreCommit
 
           if missing_versions.any?
             "You did not add the schema versions for "\
-            "#{migration_versions.join(', ')} to #{schema_files.map(&:file).join(' or ')}"
+            "#{missing_versions.join(', ')} to #{schema_files.map(&:file).join(' or ')}"
           end
         end
       end


### PR DESCRIPTION
In the current (before this fix) version, if some migration versions are common with schema versions, **all** of the migration versions are shown, instead of just missing versions.
This problem is resolved by modifying only one line, so I did it.
If you want to stick to show all the migration versions including ones that were already written in the schema file, please ignore this pull request. In that case, please consider **I** wanted only missing versions to be displayed.