### PR TITLE
Replace `File.exists?` with `File.exist?`

### DIFF
--- a/lib/pre-commit/utils/staged_files.rb
+++ b/lib/pre-commit/utils/staged_files.rb
@@ -83,7 +83,7 @@ module PreCommit
           repo_ignored?(file) ||
           ignore_extension?(file) ||
           File.directory?(file) ||
-          !File.exists?(file)
+          !File.exist?(file)
         end
 
         # If it's a source file, definitely check it.

--- a/script/benchmark/staged_files.rb
+++ b/script/benchmark/staged_files.rb
@@ -9,7 +9,7 @@ class Subject
       .reject { |file| repo_ignored?(file) }
       .reject { |file| ignore_extension?(file) }
       .reject { |file| File.directory?(file) }
-      .select { |file| File.exists?(file) }
+      .select { |file| File.exist?(file) }
 
     # If it's a source file, definitely check it.
     # Otherwise, attempt to guess if the file is binary or not.
@@ -23,7 +23,7 @@ class Subject
       .reject { |file| repo_ignored?(file) }
       .reject { |file| ignore_extension?(file) }
       .reject { |file| File.directory?(file) }
-      .select { |file| File.exists?(file) }
+      .select { |file| File.exist?(file) }
 
     # If it's a source file, definitely check it.
     # Otherwise, attempt to guess if the file is binary or not.
@@ -37,7 +37,7 @@ class Subject
       repo_ignored?(file) ||
       ignore_extension?(file) ||
       File.directory?(file) ||
-      !File.exists?(file)
+      !File.exist?(file)
     end
 
     # If it's a source file, definitely check it.


### PR DESCRIPTION
`File.exists?` has been deprecated and it will be removed since Ruby
3.2. This method has been removed on the master branch of Ruby, so
pre-commit doesn't work with the master branch of Ruby.

This PR replaces the deprecated method calls to solve this problem.